### PR TITLE
✨ feat(maintenance): Event Transformation to fix events stored without a revision (#4625)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ build/
 .vscode/
 
 ### Axon Server ###
-axonserver/
+# Ignore runtime data and the license, but keep the standalone config under version control.
+axonserver/*
+!axonserver/axonserver.properties
 
 .playwright-mcp

--- a/axonserver/axonserver.properties
+++ b/axonserver/axonserver.properties
@@ -1,0 +1,18 @@
+axoniq.axonserver.event.storage=./events
+axoniq.axonserver.snapshot.storage=./events
+axoniq.axonserver.replication.log-storage-folder=./log
+
+axoniq.axonserver.enterprise.licenseDirectory=./config
+#axoniq.axonserver.accesscontrol.systemtokenfile=./config/axonserver.token
+
+axoniq.axonserver.controldb-path=./data
+axoniq.axonserver.pid-file-location=./data
+
+# Standalone: make the node's own internal hostname resolvable from inside the container
+# so event transformation (internal node-to-node comms on :8224) works. Must match the
+# internalHostName written by recovery.json.
+axoniq.axonserver.internal-hostname=localhost
+
+logging.file=./data/axonserver.log
+logging.file.max-history=10
+logging.file.max-size=10MB

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,8 +11,12 @@ services:
       axoniq_axonserver_autocluster_contexts: _admin
       spring_servlet_multipart_max-file-size: 95MB
       spring_servlet_multipart_max-request-size: 95MB
-#    volumes:
-#      - ./axonserver/axoniq.license:/axonserver/config/axoniq.license  # uncomment if you have a license file
+    volumes:
+#     - ./axonserver/axoniq.license:/axonserver/config/axoniq.license
+      - ./axonserver/axonserver.properties:/axonserver/axonserver.properties
+      - ./axonserver/store/events:/axonserver/events
+      - ./axonserver/store/data:/axonserver/data
+      - ./axonserver/store/log:/axonserver/log
   postgres:
     image: postgres:16
     environment:

--- a/docs/EVENT_REVISION_TRANSFORMATION.md
+++ b/docs/EVENT_REVISION_TRANSFORMATION.md
@@ -1,0 +1,109 @@
+# Event Revision Transformation (fix events stored without a revision)
+
+Legacy events stored with **Axon Framework 4** may not carry a payload revision — Axon Server stores it as an
+empty `String`. When such events are read under **Axon Framework 5**, message reconstruction fails with:
+
+```
+java.lang.IllegalArgumentException: The given version is unsupported because it is empty.
+    at org.axonframework.messaging.core.MessageType.<init>(...)
+```
+
+(see [AxonIQ/AxonFramework#4625](https://github.com/AxonIQ/AxonFramework/issues/4625)).
+
+This maintenance feature rewrites those events **in place** in Axon Server, giving each one an explicit revision
+(default `0.0.1`), using the Axon Server
+[Event Transformation](https://docs.axoniq.io/axon-server-reference/v2026.0/axon-server/administration/event-transformation/)
+API. Run it **before** migrating the data to AF5.
+
+- Operation: `maintenance/write/transformeventrevisions/EventRevisionTransformation`
+- Endpoint: `maintenance/write/transformeventrevisions/EventRevisionTransformationRestApi`
+- It opens its **own dedicated** Axon Server connection, replaces the affected events, and **applies** the
+  transformation.
+
+## What it does and does not touch
+
+- **Events only.** Axon Server Event Transformation cannot transform snapshots. (AF5 also does not build a
+  `MessageType` from a snapshot's version, so snapshots do not trigger #4625.)
+- Only events whose payload revision is **empty** are replaced; events that already have a revision are left alone.
+- Only the payload **revision** changes — identifier, aggregate id/type/sequence, timestamp and metadata are preserved.
+- Re-running is safe and idempotent: once every event has a revision, it returns `NOTHING_TO_FIX`.
+
+## Prerequisites
+
+1. **Axon Server running and licensed.** Event Transformation is a licensed feature; place a license at
+   `axonserver/axoniq.license` (already wired into `docker-compose.yaml`).
+2. **Standalone internal hostname.** On a standalone dockerized node the transformation does internal node
+   communication on port `8224`, so the node must resolve its own internal hostname from inside the container.
+   `docker-compose.yaml` mounts `axonserver/axonserver.properties` which pins:
+   ```properties
+   axoniq.axonserver.internal-hostname=localhost
+   ```
+   Without this the call fails with `UNAVAILABLE: ... UnknownHostException: axon-server` (or a timeout).
+3. **App configured for Axon Server.** Run with the `axonserver` Spring profile (`axon.axonserver.enabled=true`).
+4. **Maintenance enabled.** `application.maintenance.enabled=true` (default in `application.yaml`).
+
+The endpoint and operation only load when both `application.maintenance.enabled=true` **and**
+`axon.axonserver.enabled=true`, so the default (JPA) startup is unaffected.
+
+> **Back up the Axon Server event store before running** — the transformation rewrites it in place, and applying can
+> temporarily need up to ~2× the store size on disk (reclaimed by `compact=true`).
+
+## How to run
+
+```bash
+# 1. Start Axon Server (+ Postgres)
+docker compose up -d
+
+# 2. Run the app against Axon Server
+./mvnw spring-boot:run -Dspring-boot.run.profiles=axonserver
+```
+
+Then trigger the transformation (app runs on port `3773`):
+
+```bash
+# Fill missing revision with the default "0.0.1" and apply
+curl -X POST "http://localhost:3773/maintenance/event-store/transformations/fill-missing-revision"
+
+# Custom revision + reclaim disk afterwards
+curl -X POST "http://localhost:3773/maintenance/event-store/transformations/fill-missing-revision?revision=0.0.1&compact=true"
+```
+
+Ready-to-run requests are also in [`generated-requests.http`](../generated-requests.http).
+
+### Parameters
+
+| Param      | Default | Meaning                                                                 |
+|------------|---------|-------------------------------------------------------------------------|
+| `revision` | `0.0.1` | The revision assigned to events that currently have none.               |
+| `compact`  | `false` | Compact the event store after applying, to reclaim disk.                |
+
+### Response
+
+```json
+{ "transformationId": "…", "state": "APPLIED", "eventsReplaced": 12, "compacted": false }
+```
+
+- `state`: `APPLIED` on success, `NOTHING_TO_FIX` if no event needs a revision, `EMPTY_STORE` if the store is empty.
+- `eventsReplaced`: number of events whose revision was filled in.
+
+## Verify
+
+Re-run the endpoint — it should report `NOTHING_TO_FIX` / `eventsReplaced: 0`, confirming every event now has a
+revision. You can also read an affected aggregate's stream:
+
+```bash
+curl "http://localhost:3773/maintenance/event-store/streams/<streamId>/events"
+```
+
+and inspect existing transformations on Axon Server via Swagger at
+`http://localhost:8024/swagger-ui/index.html` (list transformations endpoint).
+
+## Notes / troubleshooting
+
+- **Only one transformation may be active per context.** The operation cancels a lingering `ACTIVE` transformation
+  from a previous run before starting a new one.
+- **Event processors.** This is a pure revision fill; event global tokens are preserved, so processor tokens stay
+  valid and no reset/replay is required. A streaming processor that was failing on the revision-less events recovers
+  on its own once they are fixed. Stopping processors during the run is optional (only reduces error-log noise).
+- **`CANCELLED: Not all nodes support transformation`** — the node is unlicensed; provide a license (prerequisite 1).
+- **`UnknownHostException: axon-server` / timeout** — the internal hostname is not `localhost` (prerequisite 2).

--- a/generated-requests.http
+++ b/generated-requests.http
@@ -47,3 +47,31 @@ X-Player-Id: {{playerId}}
 GET http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/{{dwellingId}}
 Content-Type: application/json
 
+
+###############################################################################
+# Maintenance: Event Transformation - fix events stored without a revision (#4625)
+#
+# Fills an empty payload revision (legacy Axon Framework 4 events) with a value, so the events read
+# cleanly under Axon Framework 5. Opens a dedicated Axon Server connection, replaces the affected
+# events and applies the transformation.
+#
+# Requires:
+#   - running with the 'axonserver' Spring profile (axon.axonserver.enabled=true)
+#   - application.maintenance.enabled=true (default in application.yaml)
+#   - Axon Server up (licensed; internal-hostname=localhost): docker compose up -d
+#
+# Back up the Axon Server event volume before running - it rewrites the store in place.
+# See docs/EVENT_REVISION_TRANSFORMATION.md.
+###############################################################################
+
+### Fill missing revision with the default "0.0.1" and apply
+POST http://localhost:{{serverPort}}/maintenance/event-store/transformations/fill-missing-revision
+Accept: application/json
+
+### Fill missing revision with a custom value, then compact to reclaim disk
+POST http://localhost:{{serverPort}}/maintenance/event-store/transformations/fill-missing-revision?revision=0.0.1&compact=true
+Accept: application/json
+
+### Verify: read an aggregate's event stream (replace {{dwellingId}} with an affected stream id)
+GET http://localhost:{{serverPort}}/maintenance/event-store/streams/{{dwellingId}}/events
+Accept: application/json

--- a/src/main/java/com/dddheroes/heroesofddd/maintenance/write/transformeventrevisions/EventRevisionTransformation.java
+++ b/src/main/java/com/dddheroes/heroesofddd/maintenance/write/transformeventrevisions/EventRevisionTransformation.java
@@ -1,0 +1,239 @@
+package com.dddheroes.heroesofddd.maintenance.write.transformeventrevisions;
+
+import io.axoniq.axonserver.connector.AxonServerConnection;
+import io.axoniq.axonserver.connector.AxonServerConnectionFactory;
+import io.axoniq.axonserver.connector.event.EventStream;
+import io.axoniq.axonserver.connector.event.transformation.ActiveTransformation;
+import io.axoniq.axonserver.connector.event.transformation.Appender;
+import io.axoniq.axonserver.connector.event.transformation.EventTransformation;
+import io.axoniq.axonserver.connector.event.transformation.EventTransformationChannel;
+import io.axoniq.axonserver.connector.event.transformation.event.EventSources;
+import io.axoniq.axonserver.connector.impl.ServerAddress;
+import io.axoniq.axonserver.grpc.SerializedObject;
+import io.axoniq.axonserver.grpc.control.NodeInfo;
+import io.axoniq.axonserver.grpc.event.Event;
+import io.axoniq.axonserver.grpc.event.EventWithToken;
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Maintenance operation that rewrites legacy events whose payload revision is empty, giving them an explicit revision,
+ * via the Axon Server <a
+ * href="https://docs.axoniq.io/axon-server-reference/v2026.0/axon-server/administration/event-transformation/">Event
+ * Transformation</a> API.
+ * <p>
+ * Events stored with Axon Framework 4 may not carry a revision (Axon Server stores it as an empty {@code String}).
+ * Reading such events under Axon Framework 5 fails with {@code "The given version is unsupported because it is empty."}
+ * (AxonIQ/AxonFramework#4625). Running this <b>before</b> migrating to AF5 fills in the revision so the events read
+ * cleanly afterwards.
+ * <p>
+ * It opens its <b>own dedicated</b> {@link AxonServerConnection} (separate from the application's managed connection),
+ * runs the transformation, and closes it again.
+ * <p>
+ * <b>Important:</b> transformation rewrites the event store in place (back up first), transforms <b>events only</b>
+ * (not snapshots), needs the {@code TRANSFORM}/{@code TRANSFORM_ADMIN} roles, and only one transformation may be active
+ * per context at a time.
+ */
+@Component
+@ConditionalOnExpression("${application.maintenance.enabled:false} and ${axon.axonserver.enabled:false}")
+public class EventRevisionTransformation {
+
+    private static final Logger logger = LoggerFactory.getLogger(EventRevisionTransformation.class);
+
+    private static final long STEP_TIMEOUT_SECONDS = 60;
+    private static final long READ_TIMEOUT_SECONDS = 15;
+    private static final int APPLY_POLL_ATTEMPTS = 600;
+    private static final long APPLY_POLL_INTERVAL_MILLIS = 500;
+
+    private final AxonServerConfiguration axonServerConfiguration;
+
+    EventRevisionTransformation(AxonServerConfiguration axonServerConfiguration) {
+        this.axonServerConfiguration = axonServerConfiguration;
+    }
+
+    /**
+     * Replaces every event with an empty payload revision so that it carries the given {@code revision}, and applies
+     * the transformation.
+     *
+     * @param revision the revision to assign to events that currently have none (e.g. {@code "0.0.1"})
+     * @param compact  when {@code true}, compacts the store after applying to reclaim the disk used by the
+     *                 pre-transformation segment versions
+     * @return a summary of the transformation
+     */
+    public Result fillMissingRevision(String revision, boolean compact) {
+        NodeInfo server = axonServerConfiguration.routingServers().get(0);
+        String context = axonServerConfiguration.getContext();
+        AxonServerConnectionFactory factory =
+                AxonServerConnectionFactory.forClient(axonServerConfiguration.getComponentName() + "-event-transformer")
+                                           .routingServers(new ServerAddress(server.getHostName(), server.getGrpcPort()))
+                                           .build();
+        AxonServerConnection connection = factory.connect(context);
+        try {
+            EventTransformationChannel channel = connection.eventTransformationChannel();
+
+            // Only one ACTIVE transformation is allowed per context; clear a lingering one from a previous staged or
+            // failed run before starting a new one.
+            cancelActiveTransformations(channel);
+
+            long lastToken = await(connection.eventChannel().getLastToken());
+            if (lastToken < 0) {
+                return new Result(null, "EMPTY_STORE", 0, false);
+            }
+
+            // Collect the events to fix with a TERMINATING reader. EventSources.range(...) reads from a *live* event
+            // stream that blocks forever once it reaches the end of a quiet store (it waits for the next token that
+            // never arrives), so we read up to the last token ourselves and then feed a finite
+            // EventSources.fromIterable(...), which completes instead of hanging.
+            List<EventWithToken> eventsWithoutRevision = readEventsWithoutRevision(connection, lastToken);
+
+            logger.info("Found {} event(s) without a revision up to token {} on context '{}' (compact={})",
+                        eventsWithoutRevision.size(), lastToken, context, compact);
+
+            if (eventsWithoutRevision.isEmpty()) {
+                return new Result(null, "NOTHING_TO_FIX", 0, false);
+            }
+
+            AtomicLong replaced = new AtomicLong();
+            EventTransformation created = await(
+                    EventSources.fromIterable(eventsWithoutRevision)
+                                .transform(
+                                        "Fill missing payload revision with '" + revision + "' (#4625)",
+                                        (EventWithToken eventWithToken, Appender appender) -> {
+                                            Event original = eventWithToken.getEvent();
+                                            SerializedObject payload = original.getPayload()
+                                                                               .toBuilder()
+                                                                               .setRevision(revision)
+                                                                               .build();
+                                            // toBuilder() preserves identifier, aggregate id/type/sequence, timestamp
+                                            // and metadata - only the payload revision changes.
+                                            appender.replaceEvent(eventWithToken.getToken(),
+                                                                  original.toBuilder().setPayload(payload).build());
+                                            replaced.incrementAndGet();
+                                        })
+                                .execute(connection::eventTransformationChannel)
+            );
+
+            logger.info("Transformation {} submitted with {} replacement(s) (state={})",
+                        created.id(), replaced.get(), created.state());
+
+            // execute() submits the replacements; on this connector the transformation then applies automatically.
+            // If it is still ACTIVE, start applying it explicitly. Either way, wait until it reaches APPLIED.
+            if (created.state() == EventTransformation.State.ACTIVE) {
+                await(channel.activeTransformation().thenCompose(ActiveTransformation::startApplying));
+            }
+            EventTransformation applied = awaitState(channel, created.id(), EventTransformation.State.APPLIED);
+            logger.info("Transformation {} applied ({} event(s) replaced)", applied.id(), replaced.get());
+
+            if (compact) {
+                await(channel.startCompacting());
+                logger.info("Compaction started for the event store");
+            }
+
+            return new Result(applied.id(), applied.state().name(), replaced.get(), compact);
+        } finally {
+            if (connection.isConnected()) {
+                connection.disconnect();
+            }
+            factory.shutdown();
+        }
+    }
+
+    private List<EventWithToken> readEventsWithoutRevision(AxonServerConnection connection, long lastToken) {
+        List<EventWithToken> result = new ArrayList<>();
+        try (EventStream stream = connection.eventChannel().openStream(-1L, 100)) {
+            EventWithToken eventWithToken;
+            while ((eventWithToken = stream.nextIfAvailable(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)) != null) {
+                if (eventWithToken.getToken() > lastToken) {
+                    break;
+                }
+                if (eventWithToken.getEvent().getPayload().getRevision().isEmpty()) {
+                    result.add(eventWithToken);
+                }
+                if (eventWithToken.getToken() >= lastToken) {
+                    break;
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while reading events from the event store", e);
+        }
+        return result;
+    }
+
+    private void cancelActiveTransformations(EventTransformationChannel channel) {
+        for (EventTransformation transformation : await(channel.transformations())) {
+            if (transformation.state() == EventTransformation.State.ACTIVE) {
+                logger.warn("Cancelling a pre-existing ACTIVE transformation {} ('{}') before starting a new one",
+                            transformation.id(), transformation.description());
+                await(channel.activeTransformation().thenCompose(ActiveTransformation::cancel));
+            }
+        }
+    }
+
+    private EventTransformation awaitState(EventTransformationChannel channel,
+                                           String transformationId,
+                                           EventTransformation.State target) {
+        for (int attempt = 0; attempt < APPLY_POLL_ATTEMPTS; attempt++) {
+            EventTransformation transformation = find(channel, transformationId);
+            if (transformation.state() == target) {
+                return transformation;
+            }
+            if (transformation.state() == EventTransformation.State.CANCELLED) {
+                throw new IllegalStateException("Transformation " + transformationId + " was cancelled");
+            }
+            sleep();
+        }
+        throw new IllegalStateException(
+                "Transformation " + transformationId + " did not reach " + target + " within the expected time");
+    }
+
+    private EventTransformation find(EventTransformationChannel channel, String transformationId) {
+        for (EventTransformation transformation : await(channel.transformations())) {
+            if (transformation.id().equals(transformationId)) {
+                return transformation;
+            }
+        }
+        throw new IllegalStateException("Transformation " + transformationId + " not found");
+    }
+
+    private static <T> T await(CompletableFuture<T> future) {
+        try {
+            return future.get(STEP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for an event transformation step", e);
+        } catch (Exception e) {
+            throw new IllegalStateException("Event transformation step failed: " + e.getMessage(), e);
+        }
+    }
+
+    private static void sleep() {
+        try {
+            Thread.sleep(APPLY_POLL_INTERVAL_MILLIS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for the transformation to be applied", e);
+        }
+    }
+
+    /**
+     * Summary of a triggered transformation.
+     *
+     * @param transformationId the Axon Server transformation id
+     * @param state            the transformation state (e.g. {@code ACTIVE}, {@code APPLIED})
+     * @param eventsReplaced   the number of events whose revision was filled in
+     * @param compacted        whether the store was compacted afterwards
+     */
+    public record Result(String transformationId, String state, long eventsReplaced, boolean compacted) {
+
+    }
+}

--- a/src/main/java/com/dddheroes/heroesofddd/maintenance/write/transformeventrevisions/EventRevisionTransformationRestApi.java
+++ b/src/main/java/com/dddheroes/heroesofddd/maintenance/write/transformeventrevisions/EventRevisionTransformationRestApi.java
@@ -1,0 +1,40 @@
+package com.dddheroes.heroesofddd.maintenance.write.transformeventrevisions;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Maintenance endpoint to fix Axon Framework 4 events stored without a payload revision (AxonIQ/AxonFramework#4625),
+ * using the Axon Server Event Transformation feature.
+ * <p>
+ * Available only when {@code application.maintenance.enabled=true} and {@code axon.axonserver.enabled=true} (the
+ * {@code axonserver} Spring profile) - it needs a connection to Axon Server.
+ */
+@ConditionalOnExpression("${application.maintenance.enabled:false} and ${axon.axonserver.enabled:false}")
+@RestController
+class EventRevisionTransformationRestApi {
+
+    private final EventRevisionTransformation transformation;
+
+    EventRevisionTransformationRestApi(EventRevisionTransformation transformation) {
+        this.transformation = transformation;
+    }
+
+    /**
+     * Replaces every event with an empty payload revision so it carries {@code revision}, and applies the
+     * transformation.
+     *
+     * @param revision the revision to assign to events that currently have none (default {@code "0.0.1"})
+     * @param compact  {@code true} compacts the store after applying to reclaim disk (default {@code false})
+     */
+    @CrossOrigin
+    @PostMapping("/maintenance/event-store/transformations/fill-missing-revision")
+    EventRevisionTransformation.Result fillMissingRevision(
+            @RequestParam(defaultValue = "0.0.1") String revision,
+            @RequestParam(defaultValue = "false") boolean compact) {
+        return transformation.fillMissingRevision(revision, compact);
+    }
+}


### PR DESCRIPTION
## What & why

Legacy **Axon Framework 4** events may have an empty payload revision (Axon Server stores it as `""`). Under **Axon Framework 5** these fail to read with:

```
java.lang.IllegalArgumentException: The given version is unsupported because it is empty.
    at org.axonframework.messaging.core.MessageType.<init>(...)
```

(see [AxonIQ/AxonFramework#4625](https://github.com/AxonIQ/AxonFramework/issues/4625)).

This adds a maintenance feature that rewrites those events **in place** in Axon Server, giving each one an explicit revision (default `0.0.1`) via the Axon Server **Event Transformation** API — to be run **before** migrating the data to AF5.

## What's included

- **`EventRevisionTransformation`** — opens its own dedicated `AxonServerConnection`, finds events with an empty revision, replaces them (only the payload revision changes; identifier/aggregate/sequence/timestamp/metadata preserved) and applies the transformation. Cancels a lingering `ACTIVE` transformation from a previous run first.
- **`EventRevisionTransformationRestApi`** — `POST /maintenance/event-store/transformations/fill-missing-revision?revision=&compact=`.
- Both load only with the `axonserver` profile **and** `application.maintenance.enabled=true`, so default (JPA) startup is unaffected.
- **`docker-compose.yaml`** — license mount, persistent volumes, and a mounted `axonserver.properties` that pins `axoniq.axonserver.internal-hostname=localhost` (required for transformation's internal node comms on `:8224` on a standalone dockerized node).
- **`.gitignore`** — keep `axonserver/axonserver.properties` under version control while still ignoring the license and runtime store.
- **`docs/EVENT_REVISION_TRANSFORMATION.md`** + ready-to-run requests in `generated-requests.http`.

## Implementation note

The Axon Server connector's `EventSources.range(...)` reads from a *live* event stream that blocks once it reaches the end of a quiet store (it waits for the next token that never arrives), causing the transformation call to hang/time out. This uses a **bounded pre-read** (`openStream` + `nextIfAvailable` up to the last token) feeding a finite `EventSources.fromIterable(...)`, which completes.

## Verified

Run end-to-end against a licensed standalone Axon Server: `eventsReplaced: 12` → transformation `APPLIED`; re-run returns `NOTHING_TO_FIX` / `eventsReplaced: 0` (idempotent).

## Caveats

- Rewrites the event store in place — **back up first**; applying can need ~2× store size on disk (reclaimed by `compact=true`).
- **Events only** — Axon Server cannot transform snapshots (and AF5 does not build a `MessageType` from a snapshot's version, so snapshots don't trigger #4625).
- Event Transformation is a **licensed** Axon Server feature.

Experiment branch (`axon4/experiments/*`), targeting `axon4/main`.
