### PR TITLE
Add AF4 distributed tracing & observability baseline plus query-type examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `./mvnw test -Dtest=ClassName` - Run specific test class
 - `./mvnw test -Dtest=ClassName#methodName` - Run specific test method
 
+### Optional Tracing Instrumentation (opt-in, build-time)
+JDBC/JPA and gRPC (Axon Server) tracing dependencies are excluded from a default build. Add them per feature
+via Maven properties (they activate the `tracing-database` / `tracing-grpc` profiles in `pom.xml`); they still
+require the `observability` Spring profile at runtime to actually emit spans:
+- `-Dtracing.database.enabled=true` - include JDBC/JPA tracing (datasource-micrometer)
+- `-Dtracing.grpc.enabled=true` - include Axon Server gRPC tracing (opentelemetry-grpc)
+- `./mvnw verify -Dtracing.database.enabled=true -Dtracing.grpc.enabled=true` - full tracing golden-master
+  (`JaegerTracingIntegrationTest` skips its JPA/gRPC span assertions when the JARs are absent)
+
 ### Infrastructure
 - `docker compose up` - Start Axon Server and PostgreSQL containers
 - `docker compose down` - Stop containers

--- a/docker-compose.observability-jaeger.yaml
+++ b/docker-compose.observability-jaeger.yaml
@@ -1,7 +1,7 @@
 services:
   jaeger:
     image: jaegertracing/jaeger:2.5.0
-    container_name: jaeger
+    container_name: jaeger4
     environment:
       - LOG_LEVEL=info
     ports:

--- a/generated-requests.http
+++ b/generated-requests.http
@@ -3,7 +3,7 @@
 ### BuildDwelling
 @gameId = scenario-1
 @playerId = player-1
-@dwellingId = dwelling-8
+@dwellingId = dwelling-31
 
 ### BuildDwelling
 PUT http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/{{dwellingId}}

--- a/generated-requests.http
+++ b/generated-requests.http
@@ -11,13 +11,13 @@
 @serverPort = 3773
 @gameId = scenario-1
 @playerId = player-1
-@dwellingId = dwelling-81
-@dwellingId2 = dwelling-82
+@dwellingId = dwelling-1
+@dwellingId2 = dwelling-2
 @armyId = army-1
 
-### ─────────────────────────────────────────────────────────────
-### 1. Setup — build two dwellings (write side)
-### ─────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────
+# 1. Setup — build two dwellings (write side)
+# ─────────────────────────────────────────────────────────────
 
 ### BuildDwelling #1 (angel)
 PUT http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/{{dwellingId}}
@@ -44,43 +44,43 @@ X-Player-Id: {{playerId}}
   }
 }
 
-### ─────────────────────────────────────────────────────────────
-### 2. Single point-to-point query — queryGateway.query
-### ─────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────
+# 2. Single point-to-point query — queryGateway.query
+# ─────────────────────────────────────────────────────────────
 
 ### GetDwellingById
 GET http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/{{dwellingId}}
 Accept: application/json
 
-### ─────────────────────────────────────────────────────────────
-### 3. Multi-result query — query + ResponseTypes.multipleInstancesOf
-###    Returns a JSON array of every dwelling in the game.
-### ─────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────
+# 3. Multi-result query — query + ResponseTypes.multipleInstancesOf
+#    Returns a JSON array of every dwelling in the game.
+# ─────────────────────────────────────────────────────────────
 
 ### ListDwellings
 GET http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/list
 Accept: application/json
 
-### ─────────────────────────────────────────────────────────────
-### 4. Streaming query — queryGateway.streamingQuery (Server-Sent Events)
-###    Emits one SSE event per dwelling, then completes.
-### ─────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────
+# 4. Streaming query — queryGateway.streamingQuery (Server-Sent Events)
+#    Emits one SSE event per dwelling, then completes.
+# ─────────────────────────────────────────────────────────────
 
 ### StreamDwellings
 GET http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/stream
 Accept: text/event-stream
 
-### ─────────────────────────────────────────────────────────────
-### 5. Subscription query — queryGateway.subscriptionQuery (live SSE)
-###
-###    HOW TO SEE IT IN ACTION:
-###    a) Send "WatchDwelling" below — it stays OPEN and immediately streams the
-###       dwelling's CURRENT state as the first SSE event.
-###    b) With that request still running, send the two write requests underneath
-###       (increase available creatures, then recruit). Each one pushes a fresh
-###       SSE event into the open watch stream — availableCreatures 0 -> 5 -> 2.
-###    c) Stop the WatchDwelling request to close the subscription.
-### ─────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────
+# 5. Subscription query — queryGateway.subscriptionQuery (live SSE)
+#
+#    HOW TO SEE IT IN ACTION:
+#    a) Send "WatchDwelling" below — it stays OPEN and immediately streams the
+#       dwelling's CURRENT state as the first SSE event.
+#    b) With that request still running, send the two write requests underneath
+#       (increase available creatures, then recruit). Each one pushes a fresh
+#       SSE event into the open watch stream — availableCreatures 0 -> 5 -> 2.
+#    c) Stop the WatchDwelling request to close the subscription.
+# ─────────────────────────────────────────────────────────────
 
 ### WatchDwelling (leave running, then fire the two writes below)
 GET http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/{{dwellingId}}/watch

--- a/generated-requests.http
+++ b/generated-requests.http
@@ -3,7 +3,7 @@
 ### BuildDwelling
 @gameId = scenario-1
 @playerId = player-1
-@dwellingId = dwelling-1
+@dwellingId = dwelling-8
 
 ### BuildDwelling
 PUT http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/{{dwellingId}}

--- a/generated-requests.http
+++ b/generated-requests.http
@@ -1,11 +1,25 @@
-@serverPort = 3773
+# Creature-recruitment: query-type showcase (Axon Framework 4)
+#
+# Run top-to-bottom against a running app (`./mvnw spring-boot:run`, needs `docker compose up`).
+#
+# Demonstrates the four Axon Framework 4 query dispatch styles:
+#   - single point-to-point ...... GET /dwellings/{id}          (query)
+#   - multi-result ............... GET /dwellings/list           (query + ResponseTypes.multipleInstancesOf)
+#   - streaming .................. GET /dwellings/stream         (streamingQuery, SSE)
+#   - subscription (live) ........ GET /dwellings/{id}/watch     (subscriptionQuery, SSE)
 
-### BuildDwelling
+@serverPort = 3773
 @gameId = scenario-1
 @playerId = player-1
-@dwellingId = dwelling-31
+@dwellingId = dwelling-81
+@dwellingId2 = dwelling-82
+@armyId = army-1
 
-### BuildDwelling
+### ─────────────────────────────────────────────────────────────
+### 1. Setup — build two dwellings (write side)
+### ─────────────────────────────────────────────────────────────
+
+### BuildDwelling #1 (angel)
 PUT http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/{{dwellingId}}
 Content-Type: application/json
 X-Player-Id: {{playerId}}
@@ -18,7 +32,61 @@ X-Player-Id: {{playerId}}
   }
 }
 
-### IncreaseAvailableCreatures
+### BuildDwelling #2 (pegasus)
+PUT http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/{{dwellingId2}}
+Content-Type: application/json
+X-Player-Id: {{playerId}}
+
+{
+  "creatureId": "pegasus",
+  "costPerTroop": {
+    "gold": 1000
+  }
+}
+
+### ─────────────────────────────────────────────────────────────
+### 2. Single point-to-point query — queryGateway.query
+### ─────────────────────────────────────────────────────────────
+
+### GetDwellingById
+GET http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/{{dwellingId}}
+Accept: application/json
+
+### ─────────────────────────────────────────────────────────────
+### 3. Multi-result query — query + ResponseTypes.multipleInstancesOf
+###    Returns a JSON array of every dwelling in the game.
+### ─────────────────────────────────────────────────────────────
+
+### ListDwellings
+GET http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/list
+Accept: application/json
+
+### ─────────────────────────────────────────────────────────────
+### 4. Streaming query — queryGateway.streamingQuery (Server-Sent Events)
+###    Emits one SSE event per dwelling, then completes.
+### ─────────────────────────────────────────────────────────────
+
+### StreamDwellings
+GET http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/stream
+Accept: text/event-stream
+
+### ─────────────────────────────────────────────────────────────
+### 5. Subscription query — queryGateway.subscriptionQuery (live SSE)
+###
+###    HOW TO SEE IT IN ACTION:
+###    a) Send "WatchDwelling" below — it stays OPEN and immediately streams the
+###       dwelling's CURRENT state as the first SSE event.
+###    b) With that request still running, send the two write requests underneath
+###       (increase available creatures, then recruit). Each one pushes a fresh
+###       SSE event into the open watch stream — availableCreatures 0 -> 5 -> 2.
+###    c) Stop the WatchDwelling request to close the subscription.
+### ─────────────────────────────────────────────────────────────
+
+### WatchDwelling (leave running, then fire the two writes below)
+GET http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/{{dwellingId}}/watch
+Accept: text/event-stream
+
+### IncreaseAvailableCreatures  -> watch stream emits availableCreatures = 5
 PUT http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/{{dwellingId}}/available-creatures-increases
 Content-Type: application/json
 X-Player-Id: {{playerId}}
@@ -28,24 +96,20 @@ X-Player-Id: {{playerId}}
   "increaseBy": 5
 }
 
-### RecruitCreature
+### RecruitCreature  -> watch stream emits availableCreatures = 2
 PUT http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/{{dwellingId}}/creature-recruitments
 Content-Type: application/json
 X-Player-Id: {{playerId}}
 
 {
   "creatureId": "angel",
-  "armyId": "army-1",
+  "armyId": "{{armyId}}",
   "quantity": 3,
   "expectedCost": {
     "gold": 9000,
     "gems": 3
   }
 }
-
-### Dwelling read model
-GET http://localhost:{{serverPort}}/games/{{gameId}}/dwellings/{{dwellingId}}
-Content-Type: application/json
 
 
 ###############################################################################

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,9 @@
 		<!-- 1.x line is the Spring Boot 3.x-compatible release train (2.x targets Spring Boot 4) -->
 		<datasource-micrometer.version>1.4.1</datasource-micrometer.version>
 		<java.version>23</java.version>
+		<!-- Aligned to the opentelemetry-api version managed by the Spring Boot 3.5 BOM (1.49.0):
+		     instrumentation 2.15.0-alpha ships opentelemetry-api 1.49.0. Bump both together. -->
+		<opentelemetry-instrumentation.version>2.15.0-alpha</opentelemetry-instrumentation.version>
 		<spring-ai.version>1.0.1</spring-ai.version>
 		<spring-doc.version>2.8.5</spring-doc.version>
 	</properties>
@@ -107,6 +110,16 @@
 			<groupId>net.ttddyy.observation</groupId>
 			<artifactId>datasource-micrometer-spring-boot</artifactId>
 			<version>${datasource-micrometer.version}</version>
+		</dependency>
+		<!-- gRPC tracing for the Axon Server connector channel. Provides GrpcTelemetry, whose
+		     ClientInterceptor is registered on the connection channel via a ManagedChannelCustomizer
+		     bean (see GrpcTracingConfiguration). Built from the same OpenTelemetry SDK bean as the
+		     Axon/HTTP/JDBC spans, so gRPC client spans flow through the existing OTLP pipeline.
+		     Only relevant under the axonserver profile (Axon Server is disabled by default). -->
+		<dependency>
+			<groupId>io.opentelemetry.instrumentation</groupId>
+			<artifactId>opentelemetry-grpc-1.6</artifactId>
+			<version>${opentelemetry-instrumentation.version}</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
 		<assertj.version>3.27.3</assertj.version>
 		<axon.version>4.13.1</axon.version>
 		<axoniq-console.version>1.9.3</axoniq-console.version>
+		<!-- 1.x line is the Spring Boot 3.x-compatible release train (2.x targets Spring Boot 4) -->
+		<datasource-micrometer.version>1.4.1</datasource-micrometer.version>
 		<java.version>23</java.version>
 		<spring-ai.version>1.0.1</spring-ai.version>
 		<spring-doc.version>2.8.5</spring-doc.version>
@@ -94,6 +96,17 @@
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
 			<artifactId>opentelemetry-exporter-otlp</artifactId>
+		</dependency>
+		<!-- JDBC/JPA tracing: wraps the autoconfigured HikariCP DataSource in a proxy that emits a
+		     Micrometer Observation per JDBC connection/query. These flow through the same
+		     micrometer-tracing-bridge-otel -> OTLP pipeline as the Axon and HTTP spans, so every SQL
+		     statement (Axon JPA event store + read-model projections) becomes a child span carrying
+		     the SQL text (and bind parameters). Gated to the observability profile via
+		     jdbc.datasource-proxy.enabled (see application(-observability).yaml). -->
+		<dependency>
+			<groupId>net.ttddyy.observation</groupId>
+			<artifactId>datasource-micrometer-spring-boot</artifactId>
+			<version>${datasource-micrometer.version}</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -100,27 +100,8 @@
 			<groupId>io.opentelemetry</groupId>
 			<artifactId>opentelemetry-exporter-otlp</artifactId>
 		</dependency>
-		<!-- JDBC/JPA tracing: wraps the autoconfigured HikariCP DataSource in a proxy that emits a
-		     Micrometer Observation per JDBC connection/query. These flow through the same
-		     micrometer-tracing-bridge-otel -> OTLP pipeline as the Axon and HTTP spans, so every SQL
-		     statement (Axon JPA event store + read-model projections) becomes a child span carrying
-		     the SQL text (and bind parameters). Gated to the observability profile via
-		     jdbc.datasource-proxy.enabled (see application(-observability).yaml). -->
-		<dependency>
-			<groupId>net.ttddyy.observation</groupId>
-			<artifactId>datasource-micrometer-spring-boot</artifactId>
-			<version>${datasource-micrometer.version}</version>
-		</dependency>
-		<!-- gRPC tracing for the Axon Server connector channel. Provides GrpcTelemetry, whose
-		     ClientInterceptor is registered on the connection channel via a ManagedChannelCustomizer
-		     bean (see GrpcTracingConfiguration). Built from the same OpenTelemetry SDK bean as the
-		     Axon/HTTP/JDBC spans, so gRPC client spans flow through the existing OTLP pipeline.
-		     Only relevant under the axonserver profile (Axon Server is disabled by default). -->
-		<dependency>
-			<groupId>io.opentelemetry.instrumentation</groupId>
-			<artifactId>opentelemetry-grpc-1.6</artifactId>
-			<version>${opentelemetry-instrumentation.version}</version>
-		</dependency>
+		<!-- NOTE: the JDBC/JPA and gRPC tracing dependencies are opt-in build-time toggles;
+		     they live in the 'tracing-database' / 'tracing-grpc' profiles below, not here. -->
 
 		<dependency>
 			<groupId>org.springdoc</groupId>
@@ -194,5 +175,64 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<!--
+		  Opt-in, build-time tracing toggles. Each profile adds ONLY its own instrumentation JAR to
+		  the artifact; a default build (no flags) carries neither, so normal runs stay lean. These
+		  are BUILD-TIME gates (JAR present in the artifact); the JARs still do nothing until the
+		  matching RUNTIME gate is on too - the 'observability' Spring profile plus, for JDBC,
+		  jdbc.datasource-proxy.enabled=true (see application(-observability).yaml).
+
+		  Enable per feature, independently:
+		    ./mvnw ... -Dtracing.database.enabled=true    (JDBC/JPA spans)
+		    ./mvnw ... -Dtracing.grpc.enabled=true         (Axon Server gRPC spans)
+		-->
+		<profile>
+			<id>tracing-database</id>
+			<activation>
+				<property>
+					<name>tracing.database.enabled</name>
+					<value>true</value>
+				</property>
+			</activation>
+			<dependencies>
+				<!-- JDBC/JPA tracing: wraps the autoconfigured HikariCP DataSource in a proxy that emits a
+				     Micrometer Observation per JDBC connection/query. These flow through the same
+				     micrometer-tracing-bridge-otel -> OTLP pipeline as the Axon and HTTP spans, so every SQL
+				     statement (Axon JPA event store + read-model projections) becomes a child span carrying
+				     the SQL text (and bind parameters). Runtime gate: jdbc.datasource-proxy.enabled
+				     (see application(-observability).yaml). -->
+				<dependency>
+					<groupId>net.ttddyy.observation</groupId>
+					<artifactId>datasource-micrometer-spring-boot</artifactId>
+					<version>${datasource-micrometer.version}</version>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>tracing-grpc</id>
+			<activation>
+				<property>
+					<name>tracing.grpc.enabled</name>
+					<value>true</value>
+				</property>
+			</activation>
+			<dependencies>
+				<!-- gRPC tracing for the Axon Server connector channel. Provides GrpcTelemetry, whose
+				     ClientInterceptor is registered on the connection channel via a ManagedChannelCustomizer
+				     bean (see GrpcTracingConfiguration). Built from the same OpenTelemetry SDK bean as the
+				     Axon/HTTP/JDBC spans, so gRPC client spans flow through the existing OTLP pipeline.
+				     GrpcTracingConfiguration loads GrpcTelemetry reflectively and is @ConditionalOnClass on
+				     it, so the app still compiles and runs when this JAR is absent. Only relevant under the
+				     axonserver profile (Axon Server is disabled by default). -->
+				<dependency>
+					<groupId>io.opentelemetry.instrumentation</groupId>
+					<artifactId>opentelemetry-grpc-1.6</artifactId>
+					<version>${opentelemetry-instrumentation.version}</version>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 
 </project>

--- a/src/main/java/com/dddheroes/heroesofddd/astrologers/automation/whenweeksymbolproclaimedthenincreasedwellingavailablecreatures/BuiltDwellingReadModel.java
+++ b/src/main/java/com/dddheroes/heroesofddd/astrologers/automation/whenweeksymbolproclaimedthenincreasedwellingavailablecreatures/BuiltDwellingReadModel.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 @Entity
 @Table(
         name = "read_model_built_dwelling",
-        indexes = @Index(name = "idx_game_id", columnList = "gameId")
+        indexes = @Index(name = "idx_built_dwelling_game_id", columnList = "gameId")
 )
 public class BuiltDwellingReadModel {
 

--- a/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/DwellingReadModel.java
+++ b/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/DwellingReadModel.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 @Entity
 @Table(
         name = "read_model_dwelling",
-        indexes = @Index(name = "idx_game_id", columnList = "gameId")
+        indexes = @Index(name = "idx_dwelling_game_id", columnList = "gameId")
 )
 public class DwellingReadModel {
 

--- a/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/DwellingReadModelProjector.java
+++ b/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/DwellingReadModelProjector.java
@@ -3,11 +3,13 @@ package com.dddheroes.heroesofddd.creaturerecruitment.read;
 import com.dddheroes.heroesofddd.creaturerecruitment.events.DwellingBuilt;
 import com.dddheroes.heroesofddd.creaturerecruitment.events.AvailableCreaturesChanged;
 import com.dddheroes.heroesofddd.creaturerecruitment.events.CreatureRecruited;
+import com.dddheroes.heroesofddd.creaturerecruitment.read.watchdwelling.WatchDwelling;
 import com.dddheroes.heroesofddd.shared.application.GameMetaData;
 import org.axonframework.config.ProcessingGroup;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.ResetHandler;
 import org.axonframework.messaging.annotation.MetaDataValue;
+import org.axonframework.queryhandling.QueryUpdateEmitter;
 import org.springframework.stereotype.Component;
 
 @ProcessingGroup("ReadModel_Dwelling")
@@ -15,9 +17,11 @@ import org.springframework.stereotype.Component;
 class DwellingReadModelProjector {
 
     private final DwellingReadModelRepository repository;
+    private final QueryUpdateEmitter queryUpdateEmitter;
 
-    DwellingReadModelProjector(DwellingReadModelRepository repository) {
+    DwellingReadModelProjector(DwellingReadModelRepository repository, QueryUpdateEmitter queryUpdateEmitter) {
         this.repository = repository;
+        this.queryUpdateEmitter = queryUpdateEmitter;
     }
 
     @EventHandler
@@ -30,20 +34,34 @@ class DwellingReadModelProjector {
                 0
         );
         repository.save(state);
+        emitWatchUpdate(state);
     }
 
     @EventHandler
     void on(AvailableCreaturesChanged event) {
         repository.findById(event.dwellingId())
                   .map(state -> state.withAvailableCreatures(event.changedTo()))
-                  .ifPresent(repository::save);
+                  .map(repository::save)
+                  .ifPresent(this::emitWatchUpdate);
     }
 
     @EventHandler
     void on(CreatureRecruited event) {
         repository.findById(event.dwellingId())
                   .map(state -> state.withAvailableCreaturesDecreasedBy(event.quantity()))
-                  .ifPresent(repository::save);
+                  .map(repository::save)
+                  .ifPresent(this::emitWatchUpdate);
+    }
+
+    // Emit the just-persisted state to any WatchDwelling subscription query for this dwelling.
+    // Emitting from the projecting handler (rather than a separate processor) guarantees the update
+    // reflects the value written in this same unit of work — no cross-processor race.
+    private void emitWatchUpdate(DwellingReadModel state) {
+        queryUpdateEmitter.emit(
+                WatchDwelling.class,
+                query -> query.dwellingId().raw().equals(state.getDwellingId()),
+                state
+        );
     }
 
     @ResetHandler

--- a/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/listdwellings/ListDwellings.java
+++ b/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/listdwellings/ListDwellings.java
@@ -1,0 +1,10 @@
+package com.dddheroes.heroesofddd.creaturerecruitment.read.listdwellings;
+
+import com.dddheroes.heroesofddd.shared.domain.identifiers.GameId;
+
+public record ListDwellings(GameId gameId) {
+
+    public static ListDwellings query(String gameId) {
+        return new ListDwellings(GameId.of(gameId));
+    }
+}

--- a/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/listdwellings/ListDwellingsQueryHandler.java
+++ b/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/listdwellings/ListDwellingsQueryHandler.java
@@ -12,8 +12,13 @@ import java.util.List;
  * <p>
  * The handler returns a {@link List} of results. Callers dispatch this with
  * {@code queryGateway.query(query, ResponseTypes.multipleInstancesOf(DwellingReadModel.class))},
- * which yields a {@code CompletableFuture<List<DwellingReadModel>>}. This is the alternative to
- * wrapping the collection in a dedicated {@code Result} record.
+ * which yields a {@code CompletableFuture<List<DwellingReadModel>>}.
+ * <p>
+ * Over a serializing query bus (e.g. Axon Server) this relies on the message serializer carrying
+ * generic-collection element types — see the default-typing {@code messageSerializer} in
+ * {@link com.dddheroes.heroesofddd.shared.infrastructure.SerializationConfiguration}. Without it,
+ * Jackson erases the element type and the response deserializes into an untyped {@code ArrayList},
+ * failing {@code MultipleInstancesResponseType} conversion.
  */
 @Component
 class ListDwellingsQueryHandler {

--- a/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/listdwellings/ListDwellingsQueryHandler.java
+++ b/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/listdwellings/ListDwellingsQueryHandler.java
@@ -1,0 +1,31 @@
+package com.dddheroes.heroesofddd.creaturerecruitment.read.listdwellings;
+
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModel;
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModelRepository;
+import org.axonframework.queryhandling.QueryHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Multi-result query example.
+ * <p>
+ * The handler returns a {@link List} of results. Callers dispatch this with
+ * {@code queryGateway.query(query, ResponseTypes.multipleInstancesOf(DwellingReadModel.class))},
+ * which yields a {@code CompletableFuture<List<DwellingReadModel>>}. This is the alternative to
+ * wrapping the collection in a dedicated {@code Result} record.
+ */
+@Component
+class ListDwellingsQueryHandler {
+
+    private final DwellingReadModelRepository dwellingReadModelRepository;
+
+    ListDwellingsQueryHandler(DwellingReadModelRepository dwellingReadModelRepository) {
+        this.dwellingReadModelRepository = dwellingReadModelRepository;
+    }
+
+    @QueryHandler
+    List<DwellingReadModel> handle(ListDwellings query) {
+        return dwellingReadModelRepository.findAllByGameId(query.gameId().raw());
+    }
+}

--- a/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/listdwellings/ListDwellingsRestApi.java
+++ b/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/listdwellings/ListDwellingsRestApi.java
@@ -1,0 +1,33 @@
+package com.dddheroes.heroesofddd.creaturerecruitment.read.listdwellings;
+
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModel;
+import org.axonframework.messaging.responsetypes.ResponseTypes;
+import org.axonframework.queryhandling.QueryGateway;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@RestController
+@RequestMapping("games/{gameId}")
+class ListDwellingsRestApi {
+
+    private final QueryGateway queryGateway;
+
+    ListDwellingsRestApi(QueryGateway queryGateway) {
+        this.queryGateway = queryGateway;
+    }
+
+    @GetMapping("/dwellings/list")
+    CompletableFuture<List<DwellingReadModel>> listDwellings(@PathVariable String gameId) {
+        var query = ListDwellings.query(gameId);
+
+        return queryGateway.query(
+                query,
+                ResponseTypes.multipleInstancesOf(DwellingReadModel.class)
+        );
+    }
+}

--- a/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/streamdwellings/StreamDwellings.java
+++ b/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/streamdwellings/StreamDwellings.java
@@ -1,0 +1,10 @@
+package com.dddheroes.heroesofddd.creaturerecruitment.read.streamdwellings;
+
+import com.dddheroes.heroesofddd.shared.domain.identifiers.GameId;
+
+public record StreamDwellings(GameId gameId) {
+
+    public static StreamDwellings query(String gameId) {
+        return new StreamDwellings(GameId.of(gameId));
+    }
+}

--- a/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/streamdwellings/StreamDwellingsQueryHandler.java
+++ b/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/streamdwellings/StreamDwellingsQueryHandler.java
@@ -1,0 +1,30 @@
+package com.dddheroes.heroesofddd.creaturerecruitment.read.streamdwellings;
+
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModel;
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModelRepository;
+import org.axonframework.queryhandling.QueryHandler;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+/**
+ * Streaming query example (Axon Framework 4.6+).
+ * <p>
+ * The handler returns a reactive {@link Flux}. Callers dispatch this with
+ * {@code queryGateway.streamingQuery(query, DwellingReadModel.class)}, which returns a
+ * {@link org.reactivestreams.Publisher} that emits results lazily once subscribed to. This
+ * suits large result sets that should not be materialized into a single list.
+ */
+@Component
+class StreamDwellingsQueryHandler {
+
+    private final DwellingReadModelRepository dwellingReadModelRepository;
+
+    StreamDwellingsQueryHandler(DwellingReadModelRepository dwellingReadModelRepository) {
+        this.dwellingReadModelRepository = dwellingReadModelRepository;
+    }
+
+    @QueryHandler
+    Flux<DwellingReadModel> handle(StreamDwellings query) {
+        return Flux.fromIterable(dwellingReadModelRepository.findAllByGameId(query.gameId().raw()));
+    }
+}

--- a/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/streamdwellings/StreamDwellingsRestApi.java
+++ b/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/streamdwellings/StreamDwellingsRestApi.java
@@ -1,0 +1,32 @@
+package com.dddheroes.heroesofddd.creaturerecruitment.read.streamdwellings;
+
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModel;
+import org.axonframework.queryhandling.QueryGateway;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+/**
+ * Exposes the streaming query as Server-Sent Events. Spring MVC adapts the returned reactive
+ * {@link Flux} to an SSE response (no WebFlux required, since Project Reactor is on the classpath).
+ */
+@RestController
+@RequestMapping("games/{gameId}")
+class StreamDwellingsRestApi {
+
+    private final QueryGateway queryGateway;
+
+    StreamDwellingsRestApi(QueryGateway queryGateway) {
+        this.queryGateway = queryGateway;
+    }
+
+    @GetMapping(value = "/dwellings/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    Flux<DwellingReadModel> streamDwellings(@PathVariable String gameId) {
+        var query = StreamDwellings.query(gameId);
+
+        return Flux.from(queryGateway.streamingQuery(query, DwellingReadModel.class));
+    }
+}

--- a/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/watchdwelling/WatchDwelling.java
+++ b/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/watchdwelling/WatchDwelling.java
@@ -1,0 +1,11 @@
+package com.dddheroes.heroesofddd.creaturerecruitment.read.watchdwelling;
+
+import com.dddheroes.heroesofddd.creaturerecruitment.write.DwellingId;
+import com.dddheroes.heroesofddd.shared.domain.identifiers.GameId;
+
+public record WatchDwelling(GameId gameId, DwellingId dwellingId) {
+
+    public static WatchDwelling query(String gameId, String dwellingId) {
+        return new WatchDwelling(GameId.of(gameId), DwellingId.of(dwellingId));
+    }
+}

--- a/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/watchdwelling/WatchDwellingQueryHandler.java
+++ b/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/watchdwelling/WatchDwellingQueryHandler.java
@@ -1,0 +1,29 @@
+package com.dddheroes.heroesofddd.creaturerecruitment.read.watchdwelling;
+
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModel;
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModelRepository;
+import org.axonframework.queryhandling.QueryHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * Subscription query example — the initial-result handler.
+ * <p>
+ * Callers dispatch this with {@code queryGateway.subscriptionQuery(...)}, which returns a
+ * {@code SubscriptionQueryResult} whose initial result comes from this handler and whose updates
+ * are emitted for the same dwelling (see the emit calls in
+ * {@link com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModelProjector}).
+ */
+@Component
+class WatchDwellingQueryHandler {
+
+    private final DwellingReadModelRepository dwellingReadModelRepository;
+
+    WatchDwellingQueryHandler(DwellingReadModelRepository dwellingReadModelRepository) {
+        this.dwellingReadModelRepository = dwellingReadModelRepository;
+    }
+
+    @QueryHandler
+    DwellingReadModel handle(WatchDwelling query) {
+        return dwellingReadModelRepository.findById(query.dwellingId().raw()).orElse(null);
+    }
+}

--- a/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/watchdwelling/WatchDwellingRestApi.java
+++ b/src/main/java/com/dddheroes/heroesofddd/creaturerecruitment/read/watchdwelling/WatchDwellingRestApi.java
@@ -1,0 +1,46 @@
+package com.dddheroes.heroesofddd.creaturerecruitment.read.watchdwelling;
+
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModel;
+import org.axonframework.messaging.responsetypes.ResponseTypes;
+import org.axonframework.queryhandling.QueryGateway;
+import org.axonframework.queryhandling.SubscriptionQueryResult;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+/**
+ * Exposes the subscription query as Server-Sent Events: emits the dwelling's current state, then a new
+ * event every time its available creatures change or creatures are recruited — until the client
+ * disconnects. Spring MVC adapts the returned reactive {@link Flux} to SSE (Project Reactor on classpath).
+ */
+@RestController
+@RequestMapping("games/{gameId}")
+class WatchDwellingRestApi {
+
+    private final QueryGateway queryGateway;
+
+    WatchDwellingRestApi(QueryGateway queryGateway) {
+        this.queryGateway = queryGateway;
+    }
+
+    @GetMapping(value = "/dwellings/{dwellingId}/watch", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    Flux<DwellingReadModel> watchDwelling(
+            @PathVariable String gameId,
+            @PathVariable String dwellingId
+    ) {
+        var query = WatchDwelling.query(gameId, dwellingId);
+
+        SubscriptionQueryResult<DwellingReadModel, DwellingReadModel> result = queryGateway.subscriptionQuery(
+                query,
+                ResponseTypes.instanceOf(DwellingReadModel.class),
+                ResponseTypes.instanceOf(DwellingReadModel.class)
+        );
+
+        // initial state first, then every emitted update; close the subscription when the client leaves
+        return Flux.concat(result.initialResult(), result.updates())
+                   .doFinally(signal -> result.close());
+    }
+}

--- a/src/main/java/com/dddheroes/heroesofddd/shared/infrastructure/GrpcTracingConfiguration.java
+++ b/src/main/java/com/dddheroes/heroesofddd/shared/infrastructure/GrpcTracingConfiguration.java
@@ -2,8 +2,8 @@ package com.dddheroes.heroesofddd.shared.infrastructure;
 
 import io.grpc.ClientInterceptor;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
 import org.axonframework.axonserver.connector.ManagedChannelCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,8 +20,16 @@ import org.springframework.context.annotation.Profile;
  * {@link OpenTelemetry} SDK bean as the Axon/HTTP/JDBC spans, so gRPC client spans (rpc.system=grpc,
  * rpc.service/rpc.method, status) flow through the existing OTLP pipeline.
  * <p>
- * Gated to both conditions so it neither requires the (profile-only) {@link OpenTelemetry} bean nor does any work
- * when there is no channel to instrument:
+ * <b>Build-time gate.</b> The {@code opentelemetry-grpc-1.6} instrumentation JAR that supplies
+ * {@code io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry} is opt-in: it is only added to the artifact
+ * when the app is built with {@code -Dtracing.grpc.enabled=true} (the {@code tracing-grpc} Maven profile). To keep
+ * this class compilable and loadable when that JAR is absent, {@code GrpcTelemetry} is <b>not</b> imported at
+ * compile time - it is resolved reflectively - and the whole configuration is {@code @ConditionalOnClass} on it,
+ * so Spring skips it entirely on a lean build. Note {@link ClientInterceptor} (io.grpc) and {@link OpenTelemetry}
+ * (io.opentelemetry.api) are always on the classpath - the former via axon-server-connector, the latter via the
+ * always-present micrometer/OTLP tracing bridge - so only {@code GrpcTelemetry} needs the reflective path.
+ * <p>
+ * <b>Runtime gates.</b> Beyond the JAR being present, activation still requires:
  * <ul>
  *     <li>{@code @Profile("observability")} - the {@link OpenTelemetry} bean only exists when tracing is on
  *     (the {@code observability-jaeger}/{@code observability-elastic} groups include {@code observability}).</li>
@@ -35,12 +43,18 @@ import org.springframework.context.annotation.Profile;
  */
 @Configuration(proxyBeanMethods = false)
 @Profile("observability")
+@ConditionalOnClass(name = "io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry")
 @ConditionalOnProperty(prefix = "axon.axonserver", name = "enabled", havingValue = "true")
 public class GrpcTracingConfiguration {
 
     @Bean
-    public ManagedChannelCustomizer tracingManagedChannelCustomizer(OpenTelemetry openTelemetry) {
-        ClientInterceptor interceptor = GrpcTelemetry.create(openTelemetry).newClientInterceptor();
+    public ManagedChannelCustomizer tracingManagedChannelCustomizer(OpenTelemetry openTelemetry) throws Exception {
+        // GrpcTelemetry lives in the opt-in opentelemetry-grpc-1.6 JAR (see class Javadoc), so it is resolved
+        // reflectively rather than imported. @ConditionalOnClass above guarantees the class is present here.
+        Class<?> grpcTelemetry = Class.forName("io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry");
+        Object telemetry = grpcTelemetry.getMethod("create", OpenTelemetry.class).invoke(null, openTelemetry);
+        ClientInterceptor interceptor =
+                (ClientInterceptor) grpcTelemetry.getMethod("newClientInterceptor").invoke(telemetry);
         return builder -> builder.intercept(interceptor);
     }
 }

--- a/src/main/java/com/dddheroes/heroesofddd/shared/infrastructure/GrpcTracingConfiguration.java
+++ b/src/main/java/com/dddheroes/heroesofddd/shared/infrastructure/GrpcTracingConfiguration.java
@@ -1,0 +1,46 @@
+package com.dddheroes.heroesofddd.shared.infrastructure;
+
+import io.grpc.ClientInterceptor;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
+import org.axonframework.axonserver.connector.ManagedChannelCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * gRPC tracing for the Axon Server connector channel.
+ * <p>
+ * The only gRPC in this app is the connection to Axon Server (axon-server-connector). This registers an
+ * OpenTelemetry {@link ClientInterceptor} on that channel via Axon 4's {@link ManagedChannelCustomizer} hook:
+ * {@code AxonServerAutoConfiguration} wires the {@code ManagedChannelCustomizer} bean into the
+ * {@code AxonServerConnectionManager} channel builder, and its own default customizer is
+ * {@code @ConditionalOnMissingBean} identity, so this Spring bean wins. The interceptor is built from the same
+ * {@link OpenTelemetry} SDK bean as the Axon/HTTP/JDBC spans, so gRPC client spans (rpc.system=grpc,
+ * rpc.service/rpc.method, status) flow through the existing OTLP pipeline.
+ * <p>
+ * Gated to both conditions so it neither requires the (profile-only) {@link OpenTelemetry} bean nor does any work
+ * when there is no channel to instrument:
+ * <ul>
+ *     <li>{@code @Profile("observability")} - the {@link OpenTelemetry} bean only exists when tracing is on
+ *     (the {@code observability-jaeger}/{@code observability-elastic} groups include {@code observability}).</li>
+ *     <li>{@code axon.axonserver.enabled=true} - otherwise the app runs on the JPA event store with no gRPC.</li>
+ * </ul>
+ * <p>
+ * Note: Axon Server traffic is mostly long-lived bidirectional streams (command/query/event/control channels).
+ * gRPC client instrumentation opens one span per RPC, so a streaming call yields a single span spanning the whole
+ * stream lifetime rather than one per message - useful for connection/stream lifecycle and errors. Per-message
+ * command/event/query tracing is already provided by the framework's distributed tracing (axon-tracing-opentelemetry).
+ */
+@Configuration(proxyBeanMethods = false)
+@Profile("observability")
+@ConditionalOnProperty(prefix = "axon.axonserver", name = "enabled", havingValue = "true")
+public class GrpcTracingConfiguration {
+
+    @Bean
+    public ManagedChannelCustomizer tracingManagedChannelCustomizer(OpenTelemetry openTelemetry) {
+        ClientInterceptor interceptor = GrpcTelemetry.create(openTelemetry).newClientInterceptor();
+        return builder -> builder.intercept(interceptor);
+    }
+}

--- a/src/main/java/com/dddheroes/heroesofddd/shared/infrastructure/JdbcBackgroundConnectionTracingFilterConfiguration.java
+++ b/src/main/java/com/dddheroes/heroesofddd/shared/infrastructure/JdbcBackgroundConnectionTracingFilterConfiguration.java
@@ -1,0 +1,61 @@
+package com.dddheroes.heroesofddd.shared.infrastructure;
+
+import io.micrometer.observation.ObservationPredicate;
+import io.micrometer.tracing.Tracer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Filters out the noisy standalone JDBC traces that datasource-micrometer produces on background threads which carry
+ * no trace context — chiefly the pooled event processors' token-store claim/extend/release queries and HikariCP pool
+ * warm-up. Those run on Axon coordinator/worker threads outside any request or handler segment, so each JDBC
+ * observation ({@code jdbc.connection}, {@code jdbc.query}, {@code jdbc.result-set}) starts its own trace and shows up
+ * as a standalone {@code connection} root in Jaeger.
+ * <p>
+ * datasource-micrometer cannot filter by the calling package/class (the observation is created in the JDBC proxy
+ * layer, blind to the caller), and {@code jdbc.excluded-data-source-bean-names} is too coarse here (one shared
+ * DataSource backs both the token store and the read-model projections). Instead this registers a Micrometer
+ * {@link ObservationPredicate} that vetoes a {@code jdbc.*} observation only when it starts with <em>no current
+ * span</em> — i.e. on a background thread with no propagated trace context. JDBC observations that occur inside a
+ * request (on the request thread) or inside a framework handler segment (where the tracing context-propagation bridge
+ * has made the handler/commit span current) keep a non-null current span and are retained, so their
+ * connection/query/result-set spans still nest under the Axon/HTTP spans.
+ * <p>
+ * The noise source is the same on Axon 4 as on Axon 5: datasource-micrometer emits {@code jdbc.*} through the
+ * Micrometer Observation API (before the micrometer-tracing-bridge-otel → OTLP bridge), independently of the fact
+ * that Axon's own framework spans are created via the OpenTelemetry API directly ({@code OpenTelemetrySpanFactory}).
+ * The Micrometer {@link Tracer} (OtelTracer) autoconfigured from the bridge reports the current OpenTelemetry span,
+ * so {@code currentSpan()} is non-null exactly when a request/handler segment is active.
+ * <p>
+ * Spring Boot's observation auto-configuration applies every {@link ObservationPredicate} bean to the
+ * {@code ObservationRegistry}. Gated to the {@code observability} profile and to datasource-proxy being enabled and on
+ * the classpath, so lean builds skip it.
+ */
+@Configuration(proxyBeanMethods = false)
+@Profile("observability")
+@ConditionalOnClass(name = "net.ttddyy.observation.tracing.DataSourceObservationListener")
+@ConditionalOnProperty(prefix = "jdbc.datasource-proxy", name = "enabled", havingValue = "true")
+public class JdbcBackgroundConnectionTracingFilterConfiguration {
+
+    private static final String JDBC_OBSERVATION_PREFIX = "jdbc.";
+
+    /**
+     * Retains a {@code jdbc.*} observation only when a trace is already active on the current thread; drops the
+     * parentless background ones (token store, pool warm-up) that would otherwise become standalone root traces.
+     *
+     * @param tracer the Micrometer tracer used to detect whether a span is current on the calling thread
+     * @return an {@link ObservationPredicate} vetoing parentless JDBC observations
+     */
+    @Bean
+    ObservationPredicate skipParentlessJdbcObservations(Tracer tracer) {
+        return (name, context) -> {
+            if (name != null && name.startsWith(JDBC_OBSERVATION_PREFIX)) {
+                return tracer.currentSpan() != null;
+            }
+            return true;
+        };
+    }
+}

--- a/src/main/java/com/dddheroes/heroesofddd/shared/infrastructure/SerializationConfiguration.java
+++ b/src/main/java/com/dddheroes/heroesofddd/shared/infrastructure/SerializationConfiguration.java
@@ -10,6 +10,9 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.json.JacksonSerializer;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -17,6 +20,28 @@ import java.io.IOException;
 
 @Configuration
 public class SerializationConfiguration {
+
+    /**
+     * Message (command/query) serializer with Jackson default typing enabled, so generic-collection
+     * responses — e.g. a query dispatched with
+     * {@code ResponseTypes.multipleInstancesOf(DwellingReadModel.class)} — carry element type
+     * information across the (serializing) Axon Server query bus. Without it such a response
+     * deserializes into an untyped {@code ArrayList} and fails response-type conversion
+     * ("not convertible to a List of the expected response type").
+     * <p>
+     * Scoped to messages only: it copies the Spring {@link ObjectMapper} (keeping the value-object
+     * modules below) so the {@code events} serializer and REST JSON keep the plain mapper — the
+     * event-store format and HTTP responses are unaffected. Value objects (GameId, DwellingId, ...)
+     * are final records, so {@code NON_FINAL} default typing leaves their custom scalar form intact.
+     */
+    @Bean
+    @Qualifier("messageSerializer")
+    public Serializer messageSerializer(ObjectMapper objectMapper) {
+        return JacksonSerializer.builder()
+                                .objectMapper(objectMapper.copy())
+                                .defaultTyping()
+                                .build();
+    }
 
     @Bean
     public Module gameIdSerializationModule() {

--- a/src/main/resources/application-observability.yaml
+++ b/src/main/resources/application-observability.yaml
@@ -6,3 +6,10 @@ management:
   otlp:
     tracing:
       transport: http
+
+# JDBC/SQL tracing: wrap the HikariCP DataSource so every SQL statement (Axon JPA event store
+# + read-model projections) becomes a child span under the Axon/HTTP spans.
+jdbc:
+  datasource-proxy:
+    enabled: true
+    include-parameter-values: true   # bind parameter values in span attributes

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -71,10 +71,10 @@ axon:
     # All Axon attribute providers stay at their defaults (true)
     show-event-sourcing-handlers: false
     event-processor:
-      # Disable the StreamingEventProcessor.batch root span. Each event handler becomes
-      # its own root trace with an OpenTelemetry LINK back to the publish-event span —
-      # so Jaeger / Kibana APM render clickable "linked traces" for the cause/effect pair
-      # across async boundaries. Off by default in Axon (batch trace = no links).
+      # Keep asynchronous event handlers in the publisher trace and suppress the
+      # StreamingEventProcessor.batch span. Set distributed-in-same-trace to false
+      # to separate consumers from publishers; with batch tracing enabled they follow
+      # the framework's batch/consumer relationship, and without it they become linked roots.
       disable-batch-trace: true
       distributed-in-same-trace: true
 #  update-check:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -86,6 +86,9 @@ management:
 
 # JDBC/SQL tracing (datasource-micrometer). Off by default so normal runs are unaffected;
 # turned on by the 'observability' profile (see application-observability.yaml).
+# NOTE: this property only has any effect when the app is built with -Dtracing.database.enabled=true
+# (the 'tracing-database' Maven profile) — otherwise the datasource-micrometer JAR is not on the classpath
+# and this key is simply ignored. See AXON4_TRACING_BASELINE.md.
 jdbc:
   datasource-proxy:
     enabled: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -76,12 +76,19 @@ axon:
       # so Jaeger / Kibana APM render clickable "linked traces" for the cause/effect pair
       # across async boundaries. Off by default in Axon (batch trace = no links).
       disable-batch-trace: true
+      distributed-in-same-trace: true
 #  update-check:
 #    disabled: true
 
 management:
   tracing:
     enabled: false       # turned on by the 'observability' Spring profile
+
+# JDBC/SQL tracing (datasource-micrometer). Off by default so normal runs are unaffected;
+# turned on by the 'observability' profile (see application-observability.yaml).
+jdbc:
+  datasource-proxy:
+    enabled: false
 application:
   maintenance:
     enabled: true

--- a/src/test/java/com/dddheroes/heroesofddd/creaturerecruitment/read/listdwellings/ListDwellingsTest.java
+++ b/src/test/java/com/dddheroes/heroesofddd/creaturerecruitment/read/listdwellings/ListDwellingsTest.java
@@ -1,0 +1,81 @@
+package com.dddheroes.heroesofddd.creaturerecruitment.read.listdwellings;
+
+import com.dddheroes.heroesofddd.TestcontainersConfiguration;
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModel;
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModelTest;
+import com.dddheroes.heroesofddd.creaturerecruitment.events.DwellingBuilt;
+import com.dddheroes.heroesofddd.creaturerecruitment.write.DwellingId;
+import com.dddheroes.heroesofddd.shared.CreatureIds;
+import org.axonframework.eventhandling.gateway.EventGateway;
+import org.axonframework.messaging.responsetypes.ResponseTypes;
+import org.axonframework.queryhandling.QueryGateway;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static com.dddheroes.heroesofddd.utils.AwaitilityUtils.awaitUntilAsserted;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Demonstrates the multi-result query type: {@code queryGateway.query(query,
+ * ResponseTypes.multipleInstancesOf(...))} returning a {@code CompletableFuture<List<DwellingReadModel>>}
+ * from a handler that returns a {@link List}.
+ */
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+class ListDwellingsTest extends DwellingReadModelTest {
+
+    private final QueryGateway queryGateway;
+
+    @Autowired
+    ListDwellingsTest(
+            EventGateway eventGateway,
+            QueryGateway queryGateway
+    ) {
+        super(eventGateway);
+        this.queryGateway = queryGateway;
+    }
+
+    @Test
+    void givenNoDwellings_whenQueryMany_thenEmptyList() {
+        // when
+        var query = ListDwellings.query(GAME_ID);
+
+        // then
+        awaitUntilAsserted(() -> assertThat(listDwellings(query)).isEmpty());
+    }
+
+    @Test
+    void givenTwoDwellings_whenQueryMany_thenBothReturned() {
+        // given
+        var creatureId = CreatureIds.phoenix().raw();
+        var dwellingId1 = DwellingId.random().raw();
+        givenDwellingEvents(
+                dwellingId1,
+                new DwellingBuilt(dwellingId1, creatureId, PHOENIX_COST)
+        );
+        var dwellingId2 = DwellingId.random().raw();
+        givenDwellingEvents(
+                dwellingId2,
+                new DwellingBuilt(dwellingId2, creatureId, PHOENIX_COST)
+        );
+
+        // when
+        var query = ListDwellings.query(GAME_ID);
+
+        // then
+        awaitUntilAsserted(() -> {
+            var result = listDwellings(query);
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(DwellingReadModel::getDwellingId)
+                              .containsExactlyInAnyOrder(dwellingId1, dwellingId2);
+        });
+    }
+
+    private List<DwellingReadModel> listDwellings(ListDwellings query) {
+        return queryGateway.query(query, ResponseTypes.multipleInstancesOf(DwellingReadModel.class)).join();
+    }
+}

--- a/src/test/java/com/dddheroes/heroesofddd/creaturerecruitment/read/streamdwellings/StreamDwellingsTest.java
+++ b/src/test/java/com/dddheroes/heroesofddd/creaturerecruitment/read/streamdwellings/StreamDwellingsTest.java
@@ -1,0 +1,82 @@
+package com.dddheroes.heroesofddd.creaturerecruitment.read.streamdwellings;
+
+import com.dddheroes.heroesofddd.TestcontainersConfiguration;
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModel;
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModelTest;
+import com.dddheroes.heroesofddd.creaturerecruitment.events.DwellingBuilt;
+import com.dddheroes.heroesofddd.creaturerecruitment.write.DwellingId;
+import com.dddheroes.heroesofddd.shared.CreatureIds;
+import org.axonframework.eventhandling.gateway.EventGateway;
+import org.axonframework.queryhandling.QueryGateway;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+import static com.dddheroes.heroesofddd.utils.AwaitilityUtils.awaitUntilAsserted;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Demonstrates the streaming query type: {@code queryGateway.streamingQuery(...)} returning a
+ * reactive {@link org.reactivestreams.Publisher}. The stream is collected into a list to assert on.
+ */
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+class StreamDwellingsTest extends DwellingReadModelTest {
+
+    private final QueryGateway queryGateway;
+
+    @Autowired
+    StreamDwellingsTest(
+            EventGateway eventGateway,
+            QueryGateway queryGateway
+    ) {
+        super(eventGateway);
+        this.queryGateway = queryGateway;
+    }
+
+    @Test
+    void givenNoDwellings_whenStreamingQuery_thenEmptyStream() {
+        // when
+        var query = StreamDwellings.query(GAME_ID);
+
+        // then
+        awaitUntilAsserted(() -> assertThat(streamDwellings(query)).isEmpty());
+    }
+
+    @Test
+    void givenTwoDwellings_whenStreamingQuery_thenBothStreamed() {
+        // given
+        var creatureId = CreatureIds.phoenix().raw();
+        var dwellingId1 = DwellingId.random().raw();
+        givenDwellingEvents(
+                dwellingId1,
+                new DwellingBuilt(dwellingId1, creatureId, PHOENIX_COST)
+        );
+        var dwellingId2 = DwellingId.random().raw();
+        givenDwellingEvents(
+                dwellingId2,
+                new DwellingBuilt(dwellingId2, creatureId, PHOENIX_COST)
+        );
+
+        // when
+        var query = StreamDwellings.query(GAME_ID);
+
+        // then
+        awaitUntilAsserted(() -> {
+            var result = streamDwellings(query);
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(DwellingReadModel::getDwellingId)
+                              .containsExactlyInAnyOrder(dwellingId1, dwellingId2);
+        });
+    }
+
+    private List<DwellingReadModel> streamDwellings(StreamDwellings query) {
+        return Flux.from(queryGateway.streamingQuery(query, DwellingReadModel.class))
+                   .collectList()
+                   .block();
+    }
+}

--- a/src/test/java/com/dddheroes/heroesofddd/creaturerecruitment/read/watchdwelling/WatchDwellingTest.java
+++ b/src/test/java/com/dddheroes/heroesofddd/creaturerecruitment/read/watchdwelling/WatchDwellingTest.java
@@ -1,0 +1,93 @@
+package com.dddheroes.heroesofddd.creaturerecruitment.read.watchdwelling;
+
+import com.dddheroes.heroesofddd.TestcontainersConfiguration;
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModel;
+import com.dddheroes.heroesofddd.creaturerecruitment.read.DwellingReadModelTest;
+import com.dddheroes.heroesofddd.creaturerecruitment.events.AvailableCreaturesChanged;
+import com.dddheroes.heroesofddd.creaturerecruitment.events.DwellingBuilt;
+import com.dddheroes.heroesofddd.creaturerecruitment.write.DwellingId;
+import com.dddheroes.heroesofddd.shared.CreatureIds;
+import org.axonframework.eventhandling.gateway.EventGateway;
+import org.axonframework.messaging.responsetypes.ResponseTypes;
+import org.axonframework.queryhandling.QueryGateway;
+import org.axonframework.queryhandling.SubscriptionQueryResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static com.dddheroes.heroesofddd.utils.AwaitilityUtils.awaitUntilAsserted;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Demonstrates the subscription query type: {@code queryGateway.subscriptionQuery(...)} returning a
+ * {@code SubscriptionQueryResult} that combines the initial read-model state with live updates.
+ * Updates are emitted by {@code DwellingReadModelProjector} whenever the dwelling changes.
+ */
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+class WatchDwellingTest extends DwellingReadModelTest {
+
+    private final QueryGateway queryGateway;
+
+    @Autowired
+    WatchDwellingTest(
+            EventGateway eventGateway,
+            QueryGateway queryGateway
+    ) {
+        super(eventGateway);
+        this.queryGateway = queryGateway;
+    }
+
+    @Test
+    void givenBuiltDwelling_whenSubscribing_thenReceivesInitialStateAndLiveUpdate() {
+        // given
+        var dwellingId = DwellingId.random().raw();
+        var creatureId = CreatureIds.phoenix().raw();
+        givenDwellingEvents(
+                dwellingId,
+                new DwellingBuilt(dwellingId, creatureId, PHOENIX_COST)
+        );
+        // wait until the read model is projected, so the subscription's initial result is present
+        awaitUntilAsserted(() -> assertThat(currentState(dwellingId)).isNotNull());
+
+        // when
+        SubscriptionQueryResult<DwellingReadModel, DwellingReadModel> subscription = queryGateway.subscriptionQuery(
+                WatchDwelling.query(GAME_ID, dwellingId),
+                ResponseTypes.instanceOf(DwellingReadModel.class),
+                ResponseTypes.instanceOf(DwellingReadModel.class)
+        );
+        var received = new CopyOnWriteArrayList<DwellingReadModel>();
+        Disposable disposable = Flux.concat(subscription.initialResult(), subscription.updates())
+                                    .subscribe(received::add);
+
+        try {
+            // the initial result (availableCreatures = 0) is delivered right after subscribing
+            awaitUntilAsserted(() -> assertThat(received)
+                    .anySatisfy(state -> assertThat(state.getAvailableCreatures()).isEqualTo(0)));
+
+            // a change to the dwelling is pushed to the active subscription as an update
+            eventGateway.publish(dwellingDomainEvent(
+                    dwellingId, 1, new AvailableCreaturesChanged(dwellingId, creatureId, 5)
+            ));
+
+            // then
+            awaitUntilAsserted(() -> assertThat(received)
+                    .anySatisfy(state -> {
+                        assertThat(state.getDwellingId()).isEqualTo(dwellingId);
+                        assertThat(state.getAvailableCreatures()).isEqualTo(5);
+                    }));
+        } finally {
+            disposable.dispose();
+            subscription.close();
+        }
+    }
+
+    private DwellingReadModel currentState(String dwellingId) {
+        return queryGateway.query(WatchDwelling.query(GAME_ID, dwellingId), DwellingReadModel.class).join();
+    }
+}

--- a/src/test/java/com/dddheroes/heroesofddd/observability/AXON4_TRACING_BASELINE.md
+++ b/src/test/java/com/dddheroes/heroesofddd/observability/AXON4_TRACING_BASELINE.md
@@ -1,0 +1,134 @@
+# Axon Framework 4 — Distributed Tracing Baseline
+
+This document is the human-readable companion to `JaegerTracingIntegrationTest`. It records the **exact
+OpenTelemetry spans and attributes** that **Axon Framework 4.13.1** (`axon-tracing-opentelemetry`) emits for
+a representative command → event → projection → query flow in this application.
+
+**Why it exists:** this app is being migrated to **Axon Framework 5**. Re-running the test after the
+migration turns any change in tracing output (renamed operations, dropped spans, changed span kinds,
+renamed/added/removed attributes, broken context propagation) into a concrete, reviewable diff.
+
+> Keep this file in sync with the constants in `JaegerTracingIntegrationTest`. The test is the source of
+> truth that is actually enforced; this file explains it.
+
+## Stack under test
+
+| Component | Image | Role |
+|-----------|-------|------|
+| Axon Server | `axoniq/axonserver:latest` (Testcontainers) | event store + command/query/event routing (distributed buses) |
+| PostgreSQL | `postgres:latest` (Testcontainers) | JPA read-model store + token store |
+| Jaeger | `jaegertracing/jaeger:2.5.0` (Testcontainers) | OTLP/HTTP backend (4318) + query API (16686) |
+
+Profiles: `observability, observability-jaeger, axonserver`. Sampling `1.0`, OTLP transport HTTP,
+service name `heroesofddd`.
+
+> **Note on `management.tracing.enabled`:** the production `observability` profile
+> (`application-observability.yaml`) already sets this to `true`, and that value wins at runtime. Spring Boot,
+> however, injects a high-precedence `test` property source under `@SpringBootTest` that forces it back to
+> `false` — so the test re-enables it via `@DynamicPropertySource` (which outranks the `test` source).
+> This is a test-only concern; no production profile change is needed.
+
+## The flow (driven over HTTP)
+
+1. `PUT /games/{gameId}/dwellings/{dwellingId}` → `BuildDwelling` → `DwellingBuilt`
+2. `PUT /games/{gameId}/dwellings/{dwellingId}/available-creatures-increases` → `IncreaseAvailableCreatures` → `AvailableCreaturesChanged`
+3. `PUT /games/{gameId}/dwellings/{dwellingId}/creature-recruitments` → `RecruitCreature` → `CreatureRecruited`
+   → async automation → `AddCreatureToArmy` (Army aggregate) → `CreatureAddedToArmy`
+4. `GET /games/{gameId}/dwellings/{dwellingId}` → `GetDwellingById` query
+
+## Span naming convention (Axon 4)
+
+`OpenTelemetrySpanFactory` names spans **`<operation>(<MessageName>)`**:
+- `<MessageName>` is the **command/query name** (FQCN by default) or the **event payload simple name**.
+- Emitted under the instrumentation scope **`axon-framework`** (the tracer name from `TracingConfiguration`).
+- Because **Axon Server** is used, command/query buses are **distributed** → both local
+  (`dispatchCommand`/`handleCommand`) **and** distributed (`dispatchDistributedCommand`/`handleDistributedCommand`)
+  spans appear.
+
+## Span catalog (operation names)
+
+### Axon framework spans (`EXPECTED_AXON_FRAMEWORK_SPANS`)
+
+**CommandBus** — for each of `BuildDwelling`, `IncreaseAvailableCreatures`, `RecruitCreature`, `AddCreatureToArmy`:
+- `CommandBus.dispatchCommand(<Cmd>)` — local dispatch, kind `INTERNAL`
+- `CommandBus.dispatchDistributedCommand(<Cmd>)` — Axon Server dispatch
+- `CommandBus.handleCommand(<Cmd>)` — local handling, kind `CONSUMER`
+- `CommandBus.handleDistributedCommand(<Cmd>)` — Axon Server handling
+
+**EventBus**
+- `EventBus.publishEvent(DwellingBuilt | AvailableCreaturesChanged | CreatureRecruited | CreatureAddedToArmy)` — kind `PRODUCER`
+- `EventBus.commitEvents` — internal commit
+
+**QueryBus**
+- `QueryBus.query(GetDwellingById)` — local dispatch
+- `QueryBus.queryDistributed(GetDwellingById)` — Axon Server dispatch
+- `QueryBus.processQueryMessage(GetDwellingById)` — handling, kind `CONSUMER`
+- `QueryBus.processQueryResponse(GetDwellingById)` — internal
+
+**Repository** (event-sourced aggregate loading)
+- `Repository.load`
+- `Repository.obtainLock`
+- `Repository.initializeState(Dwelling)`
+
+**Event processors** (re-reading the events)
+- `StreamingEventProcessor.process(DwellingBuilt | AvailableCreaturesChanged | CreatureRecruited)` — pooled/streaming processors
+- `EventProcessor.process(DwellingBuilt)` — the subscribing `Read_GetAllDwellings_QueryCache` processor
+
+### `@MessageHandler` invocation spans (`EXPECTED_HANDLER_SPANS`)
+
+Wrapped by `TracingHandlerEnhancerDefinition` as `<DeclaringClass>.<method>(<ParamSimpleTypes>)`:
+- `Dwelling.decide(BuildDwelling | IncreaseAvailableCreatures | RecruitCreature)`
+- `Army.decide(AddCreatureToArmy)`
+- `DwellingReadModelProjector.on(DwellingBuilt,String)` · `on(AvailableCreaturesChanged)` · `on(CreatureRecruited)`
+- `WhenCreatureRecruitedThenAddToArmyProcessor.react(CreatureRecruited,String,String)`
+- `WhenWeekSymbolProclaimedThenIncreaseDwellingAvailableCreaturesProcessor.on(DwellingBuilt,String)`
+- `GetAllDwellingsQueryHandler.evolve(DwellingBuilt,String)`
+- `GetDwellingByIdQueryHandler.handle(GetDwellingById)`
+
+> **Baseline fact:** aggregate `@EventSourcingHandler` replays produce **no** spans, because
+> `axon.tracing.show-event-sourcing-handlers=false` in `application.yaml`.
+
+### HTTP server spans (Spring/Micrometer, not Axon) (`EXPECTED_HTTP_SERVER_SPANS`)
+- `http put /games/{gameId}/dwellings/{dwellingId}`
+- `http put /games/{gameId}/dwellings/{dwellingId}/available-creatures-increases`
+- `http put /games/{gameId}/dwellings/{dwellingId}/creature-recruitments`
+- `http get /games/{gameId}/dwellings/{dwellingId}`
+
+## Span attributes (tags)
+
+### Attribute key sets per span category
+
+| Span | Attribute keys |
+|------|----------------|
+| `CommandBus.dispatchCommand(*)` | `axon_message_id`, `axon_message_name`, `axon_message_type`, `axon_metadata_gameId`, `axon_metadata_playerId`, `axon_metadata_traceparent`, `axon_payload_type`, `otel.scope.name`, `span.kind` |
+| `CommandBus.handleCommand(*)` | *(same as dispatch)* |
+| `EventBus.publishEvent(*)` | `axon_aggregate_identifier`, `axon_message_id`, `axon_message_type`, `axon_metadata_correlationId`, `axon_metadata_gameId`, `axon_metadata_playerId`, `axon_metadata_traceId`, `axon_payload_type`, `otel.scope.name`, `span.kind` |
+| `StreamingEventProcessor.process(*)` | *(publish keys)* **+** `axon_metadata_traceparent` |
+| `QueryBus.processQueryMessage(*)` | `axon_message_id`, `axon_message_name`, `axon_message_type`, `axon_metadata_traceparent`, `axon_payload_type`, `otel.scope.name`, `span.kind` |
+| `<Class>.<handler>(*)` (handler-enhancer) | `otel.scope.name`, `span.kind` only |
+| `http put …` (Spring) | `exception`, `http.url`, `method`, `otel.scope.name` (=`org.springframework.boot`), `otel.scope.version`, `outcome`, `span.kind`, `status`, `uri` |
+
+> **Baseline asymmetries worth noting for the migration:**
+> - `publishEvent` has `correlationId`/`traceId` (Axon causation metadata) but **no** `traceparent`;
+>   the async `process` span **does** carry `traceparent` (injected on the dispatch path).
+> - The query side has **no** `axon_metadata_gameId` — `GetDwellingById` is dispatched without game metadata.
+> - Handler-enhancer spans carry **no** message attributes (only scope + kind).
+
+### Attribute values (key invariants)
+
+- `otel.scope.name = axon-framework` on **every** Axon framework span.
+- `span.kind`: dispatch (local) = `internal`, handling = `consumer`, publish = `producer`, handler-enhancer = `internal`, HTTP = `server`.
+- `axon_message_type`: `GrpcBackedCommandMessage` (command, via Axon Server), `GenericDomainEventMessage` (published event),
+  `GenericTrackedDomainEventMessage` (event in a streaming processor), `GrpcBackedQueryMessage` (query).
+- `axon_message_name` / `axon_payload_type`: fully-qualified class name of the command/query/event payload.
+- `axon_aggregate_identifier`: `Dwelling:<dwellingId>` on the dwelling's domain-event spans.
+- **Causation:** the recruit event's `axon_metadata_correlationId` and `axon_metadata_traceId` both equal the
+  originating `RecruitCreature` command's `axon_message_id`.
+- **W3C propagation:** `axon_metadata_traceparent` matches `00-<32hex>-<16hex>-<2hex>`, and the async
+  `StreamingEventProcessor.process(CreatureRecruited)` span shares the **same trace-id** as the dispatch span.
+
+## When migrating to Axon 5
+
+Re-run `JaegerTracingIntegrationTest`. Expected, intentional changes (e.g. renamed operations or attributes
+in Axon 5) should be reflected by updating the constants in the test **and** this document in the same commit,
+so the diff documents the behavioural change.

--- a/src/test/java/com/dddheroes/heroesofddd/observability/AXON4_TRACING_BASELINE.md
+++ b/src/test/java/com/dddheroes/heroesofddd/observability/AXON4_TRACING_BASELINE.md
@@ -19,6 +19,17 @@ renamed/added/removed attributes, broken context propagation) into a concrete, r
 | PostgreSQL | `postgres:latest` (Testcontainers) | JPA read-model store + token store |
 | Jaeger | `jaegertracing/jaeger:2.5.0` (Testcontainers) | OTLP/HTTP backend (4318) + query API (16686) |
 
+JDBC/JPA tracing is provided by **`net.ttddyy.observation:datasource-micrometer-spring-boot`** (`1.4.1`, the
+Spring Boot 3.x line; 2.x targets Spring Boot 4), which instruments the `DataSource` through the Micrometer
+Observation API so database spans flow through the same Micrometer → OpenTelemetry → OTLP pipeline (no
+OpenTelemetry agent needed). The proxy is **gated by `jdbc.datasource-proxy.enabled`**: `false` in the base
+`application.yaml` and `true` in `application-observability.yaml`, so it isn't even created in the default
+runtime and turns on only under the `observability` profile — matching the rest of the tracing setup. Bind
+parameter values are captured (`jdbc.datasource-proxy.include-parameter-values: true`).
+
+> This mirrors the configuration used on the Axon 5 side (`axon5/tracing-v1`), so the JDBC tracing behaviour
+> is directly comparable across the migration.
+
 Profiles: `observability, observability-jaeger, axonserver`. Sampling `1.0`, OTLP transport HTTP,
 service name `heroesofddd`.
 
@@ -93,6 +104,20 @@ Wrapped by `TracingHandlerEnhancerDefinition` as `<DeclaringClass>.<method>(<Par
 - `http put /games/{gameId}/dwellings/{dwellingId}/available-creatures-increases`
 - `http put /games/{gameId}/dwellings/{dwellingId}/creature-recruitments`
 - `http get /games/{gameId}/dwellings/{dwellingId}`
+
+### JPA/JDBC spans (datasource-micrometer, scope `org.springframework.boot`) (`EXPECTED_JPA_SPANS`)
+- `connection` — JDBC connection acquisition
+- `query` — SQL statement execution; SQL text on the `jdbc.query[0]` tag
+- `result-set` — result-set traversal
+
+> Asserted by **presence** only — the number of DB spans and the exact SQL vary per run, so they are not
+> policed exhaustively. Query-span attributes checked: `span.kind=client`,
+> `jdbc.datasource.driver=org.postgresql.Driver`, and a non-empty `jdbc.query[0]` (the SQL). Other tags seen:
+> `jdbc.datasource.name`, `jdbc.datasource.pool` (e.g. `HikariPool-1`), `peer.service`. Bind-parameter values
+> **are** captured (`jdbc.datasource-proxy.include-parameter-values: true`).
+>
+> ⚠️ Bind-parameter values can expose data. Intentional here (local/dev tracing, off by default). Revisit
+> `include-parameter-values` before enabling in any shared environment.
 
 ## Span attributes (tags)
 

--- a/src/test/java/com/dddheroes/heroesofddd/observability/AXON4_TRACING_BASELINE.md
+++ b/src/test/java/com/dddheroes/heroesofddd/observability/AXON4_TRACING_BASELINE.md
@@ -30,6 +30,13 @@ parameter values are captured (`jdbc.datasource-proxy.include-parameter-values: 
 > This mirrors the configuration used on the Axon 5 side (`axon5/tracing-v1`), so the JDBC tracing behaviour
 > is directly comparable across the migration.
 
+gRPC tracing (Axon Server connector) is provided by **`io.opentelemetry.instrumentation:opentelemetry-grpc-1.6`**
+(`2.15.0-alpha`, matching the `opentelemetry-api` 1.49.0 managed by the Spring Boot 3.5 BOM). A gRPC
+`ClientInterceptor` is registered on the Axon Server channel via Axon 4's `ManagedChannelCustomizer`
+(`GrpcTracingConfiguration`), gated to the `observability` profile **and** `axon.axonserver.enabled=true`. Also
+mirrors the Axon 5 side (the only difference is the `ManagedChannelCustomizer` package:
+`org.axonframework.axonserver.connector` on Axon 4 vs `io.axoniq.framework...` on Axon 5).
+
 Profiles: `observability, observability-jaeger, axonserver`. Sampling `1.0`, OTLP transport HTTP,
 service name `heroesofddd`.
 
@@ -118,6 +125,26 @@ Wrapped by `TracingHandlerEnhancerDefinition` as `<DeclaringClass>.<method>(<Par
 >
 > ⚠️ Bind-parameter values can expose data. Intentional here (local/dev tracing, off by default). Revisit
 > `include-parameter-values` before enabling in any shared environment.
+
+### gRPC spans — Axon Server connector (scope `io.opentelemetry.grpc-1.6`) (`EXPECTED_GRPC_SPANS`)
+
+An OpenTelemetry gRPC `ClientInterceptor` (`opentelemetry-grpc-1.6`) is registered on the Axon Server
+connection channel via Axon 4's `ManagedChannelCustomizer` hook (see `GrpcTracingConfiguration`), gated to the
+`observability` profile **and** `axon.axonserver.enabled=true`. Spans are named `<rpc.service>/<rpc.method>`:
+
+- `io.axoniq.axonserver.grpc.command.CommandService/Dispatch` — command sent to Axon Server
+- `io.axoniq.axonserver.grpc.query.QueryService/Query` — `GetDwellingById`
+- `io.axoniq.axonserver.grpc.event.EventStore/AppendEvent` — events appended
+- `io.axoniq.axonserver.grpc.event.EventStore/ListAggregateEvents` — aggregate loading
+
+Attributes on each: `rpc.system=grpc`, `rpc.service`, `rpc.method`, `rpc.grpc.status_code` (`0` = OK),
+`span.kind=client`, plus `server.address`/`server.port`, `network.peer.*`.
+
+> Asserted by **presence** only (the `Dispatch` span's attributes are checked exactly). Axon Server traffic is
+> dominated by **long-lived bidirectional streams** (command/query/event/control channels); gRPC opens one span
+> per RPC, so a streaming call yields a *single span lasting the whole connection* — it does not end during the
+> test and is therefore not asserted. Only the **unary** RPCs above end and export. Per-message tracing is
+> already covered by the framework's distributed tracing (`axon-tracing-opentelemetry`).
 
 ## Span attributes (tags)
 

--- a/src/test/java/com/dddheroes/heroesofddd/observability/AXON4_TRACING_BASELINE.md
+++ b/src/test/java/com/dddheroes/heroesofddd/observability/AXON4_TRACING_BASELINE.md
@@ -37,6 +37,20 @@ gRPC tracing (Axon Server connector) is provided by **`io.opentelemetry.instrume
 mirrors the Axon 5 side (the only difference is the `ManagedChannelCustomizer` package:
 `org.axonframework.axonserver.connector` on Axon 4 vs `io.axoniq.framework...` on Axon 5).
 
+> **Build-time toggles.** The JDBC and gRPC instrumentation JARs are **opt-in at build time** and are excluded
+> from a default build. Enable them independently via Maven properties, which activate the `tracing-database` /
+> `tracing-grpc` profiles in `pom.xml`:
+> - `-Dtracing.database.enabled=true` — adds `datasource-micrometer-spring-boot` (JDBC/JPA spans)
+> - `-Dtracing.grpc.enabled=true` — adds `opentelemetry-grpc-1.6` (Axon Server gRPC spans)
+>
+> These are a separate *build-time* gate on top of the *runtime* gates above: the JAR must be present **and**
+> the `observability` profile (plus `jdbc.datasource-proxy.enabled` / `axon.axonserver.enabled`) active before
+> spans appear. `GrpcTracingConfiguration` loads `GrpcTelemetry` reflectively and is `@ConditionalOnClass` on
+> it, so the app compiles and runs unchanged when the gRPC JAR is absent. Because the default build omits both
+> JARs, this golden-master **skips** the JPA and gRPC span assertions unless the matching JAR is on the
+> classpath — run `./mvnw verify -Dtracing.database.enabled=true -Dtracing.grpc.enabled=true` to exercise the
+> full baseline.
+
 Profiles: `observability, observability-jaeger, axonserver`. Sampling `1.0`, OTLP transport HTTP,
 service name `heroesofddd`.
 

--- a/src/test/java/com/dddheroes/heroesofddd/observability/AXON4_TRACING_BASELINE.md
+++ b/src/test/java/com/dddheroes/heroesofddd/observability/AXON4_TRACING_BASELINE.md
@@ -106,6 +106,10 @@ service name `heroesofddd`.
 - `StreamingEventProcessor.process(DwellingBuilt | AvailableCreaturesChanged | CreatureRecruited)` — pooled/streaming processors
 - `EventProcessor.process(DwellingBuilt)` — the subscribing `Read_GetAllDwellings_QueryCache` processor
 
+**Query update emitter** (publishing updates from the dwelling read-model projection)
+- `QueryUpdateEmitter.emitQueryUpdateMessage(DwellingReadModel)`
+- `QueryUpdateEmitter.scheduleQueryUpdateMessage(DwellingReadModel)`
+
 ### `@MessageHandler` invocation spans (`EXPECTED_HANDLER_SPANS`)
 
 Wrapped by `TracingHandlerEnhancerDefinition` as `<DeclaringClass>.<method>(<ParamSimpleTypes>)`:

--- a/src/test/java/com/dddheroes/heroesofddd/observability/JaegerClient.java
+++ b/src/test/java/com/dddheroes/heroesofddd/observability/JaegerClient.java
@@ -1,0 +1,92 @@
+package com.dddheroes.heroesofddd.observability;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Minimal client for the Jaeger Query HTTP API (port 16686), used by the tracing integration test
+ * to read back the spans an Axon application exported via OTLP.
+ * <p>
+ * Jaeger v2 keeps the v1 query API: {@code GET /api/traces?service=<name>&lookback=<dur>&limit=<n>}
+ * returns {@code {"data":[{"spans":[{"operationName":..,"tags":[{"key":..,"value":..}]}]}]}}.
+ * We flatten every span across every returned trace into a flat {@link Span} list so the test can
+ * assert on operation names and message attributes regardless of how Jaeger groups them into traces.
+ */
+final class JaegerClient {
+
+    /** A single span flattened out of the Jaeger response, with its tags as a flat map. */
+    record Span(String operationName, Map<String, String> tags) {
+
+        boolean operationMatches(Pattern pattern) {
+            return pattern.matcher(operationName).matches();
+        }
+
+        boolean hasTag(String key, String value) {
+            return value.equals(tags.get(key));
+        }
+    }
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+                                                    .connectTimeout(Duration.ofSeconds(5))
+                                                    .build();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String baseUrl;
+
+    JaegerClient(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    /** All spans exported by {@code serviceName} within the lookback window, flattened. */
+    List<Span> fetchSpans(String serviceName, Duration lookback) {
+        var url = "%s/api/traces?service=%s&lookback=%ss&limit=2000".formatted(
+                baseUrl,
+                URLEncoder.encode(serviceName, StandardCharsets.UTF_8),
+                lookback.toSeconds()
+        );
+        try {
+            var request = HttpRequest.newBuilder(URI.create(url))
+                                     .timeout(Duration.ofSeconds(10))
+                                     .GET()
+                                     .build();
+            var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                // Service not registered yet (no spans exported) → empty, let the caller retry.
+                return List.of();
+            }
+            return parseSpans(response.body());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to query Jaeger at " + url, e);
+        }
+    }
+
+    private List<Span> parseSpans(String body) throws Exception {
+        var spans = new ArrayList<Span>();
+        var data = objectMapper.readTree(body).path("data");
+        if (!data.isArray()) {
+            return spans;
+        }
+        for (JsonNode trace : data) {
+            for (JsonNode span : trace.path("spans")) {
+                var tags = new HashMap<String, String>();
+                for (JsonNode tag : span.path("tags")) {
+                    tags.put(tag.path("key").asText(), tag.path("value").asText());
+                }
+                spans.add(new Span(span.path("operationName").asText(), tags));
+            }
+        }
+        return spans;
+    }
+}

--- a/src/test/java/com/dddheroes/heroesofddd/observability/JaegerTracingIntegrationTest.java
+++ b/src/test/java/com/dddheroes/heroesofddd/observability/JaegerTracingIntegrationTest.java
@@ -152,6 +152,17 @@ class JaegerTracingIntegrationTest {
             "http get /games/{gameId}/dwellings/{dwellingId}"
     ));
 
+    /**
+     * JDBC/JPA spans from {@code datasource-micrometer}. The instrumented DataSource emits these as children
+     * of whichever Axon handler span is doing the DB work (token store, JPA read model). They share the
+     * {@code org.springframework.boot} instrumentation scope with the HTTP spans.
+     */
+    private static final Set<String> EXPECTED_JPA_SPANS = new TreeSet<>(List.of(
+            "connection",  // JDBC connection acquisition
+            "query",       // SQL statement execution (SQL text on the jdbc.query[0] tag)
+            "result-set"   // result-set traversal
+    ));
+
     /** Operation-name prefixes owned by Axon's framework SpanFactories — used to police for new/renamed spans. */
     private static final List<String> AXON_FRAMEWORK_PREFIXES = List.of(
             "CommandBus.", "EventBus.", "QueryBus.", "Repository.",
@@ -257,6 +268,12 @@ class JaegerTracingIntegrationTest {
                     .as("all documented HTTP server spans must be present")
                     .containsAll(EXPECTED_HTTP_SERVER_SPANS);
 
+            // JPA/JDBC spans (datasource-micrometer) — assert presence. Their count/SQL varies per run, so
+            // this side is not policed exhaustively either.
+            assertThat(operations)
+                    .as("all documented JPA/JDBC spans must be present")
+                    .containsAll(EXPECTED_JPA_SPANS);
+
             // ---------- 2) Attributes — exact key sets (regression signal for attribute add/remove) ----------
             // Command dispatch span (local): INTERNAL kind, carries the W3C traceparent it propagates downstream.
             var dispatchRecruit = findSpan(spans, "CommandBus.dispatchCommand(RecruitCreature)");
@@ -337,6 +354,14 @@ class JaegerTracingIntegrationTest {
             assertTag(httpPut, "status", "200");
             assertTag(httpPut, "outcome", "SUCCESS");
             assertTag(httpPut, "uri", "/games/{gameId}/dwellings/{dwellingId}");
+
+            // JPA/JDBC query span (datasource-micrometer): CLIENT kind, PostgreSQL driver, SQL text present.
+            var querySpan = findSpan(spans, "query");
+            assertTag(querySpan, "span.kind", "client");
+            assertTag(querySpan, "jdbc.datasource.driver", "org.postgresql.Driver");
+            assertThat(querySpan.tags())
+                    .as("query span must carry the executed SQL on the jdbc.query[0] tag")
+                    .containsKey("jdbc.query[0]");
 
             // ---------- 4) Causation + W3C context propagation (regression signal for broken correlation) ----------
             // The recruit event's correlationId/traceId point back to the originating command's message id.

--- a/src/test/java/com/dddheroes/heroesofddd/observability/JaegerTracingIntegrationTest.java
+++ b/src/test/java/com/dddheroes/heroesofddd/observability/JaegerTracingIntegrationTest.java
@@ -122,7 +122,10 @@ class JaegerTracingIntegrationTest {
             "StreamingEventProcessor.process(DwellingBuilt)",
             "StreamingEventProcessor.process(AvailableCreaturesChanged)",
             "StreamingEventProcessor.process(CreatureRecruited)",
-            "EventProcessor.process(DwellingBuilt)"
+            "EventProcessor.process(DwellingBuilt)",
+            // -- QueryUpdateEmitter: the read-model projection publishes and schedules updates --
+            "QueryUpdateEmitter.emitQueryUpdateMessage(DwellingReadModel)",
+            "QueryUpdateEmitter.scheduleQueryUpdateMessage(DwellingReadModel)"
     ));
 
     /**

--- a/src/test/java/com/dddheroes/heroesofddd/observability/JaegerTracingIntegrationTest.java
+++ b/src/test/java/com/dddheroes/heroesofddd/observability/JaegerTracingIntegrationTest.java
@@ -1,0 +1,465 @@
+package com.dddheroes.heroesofddd.observability;
+
+import com.dddheroes.heroesofddd.TestcontainersConfiguration;
+import com.dddheroes.heroesofddd.creaturerecruitment.events.CreatureRecruited;
+import com.dddheroes.heroesofddd.creaturerecruitment.read.getdwellingbyid.GetDwellingById;
+import com.dddheroes.heroesofddd.creaturerecruitment.write.recruitcreature.RecruitCreature;
+import com.dddheroes.heroesofddd.observability.JaegerClient.Span;
+import com.dddheroes.heroesofddd.shared.application.GameMetaData;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * GOLDEN-MASTER / REGRESSION BASELINE of the distributed-tracing spans produced by
+ * <b>Axon Framework 4</b> (4.13.1) + {@code axon-tracing-opentelemetry} for this application.
+ *
+ * <p>This test exists to <b>pin down the exact span names and attributes</b> Axon 4 emits for a
+ * representative command → event → projection → query flow, so that when the application is migrated
+ * to <b>Axon Framework 5</b> the same test can be re-run and any change in tracing output (renamed
+ * operations, dropped spans, changed span kinds, renamed/added/removed attributes, broken context
+ * propagation) shows up as a concrete, reviewable diff rather than going unnoticed.
+ *
+ * <p>The full Axon-4 baseline this test enforces is also written up, span by span, in
+ * {@code AXON4_TRACING_BASELINE.md} next to this file — keep the two in sync.
+ *
+ * <h2>What the spans look like in Axon 4</h2>
+ * Axon's {@code OpenTelemetrySpanFactory} names spans {@code "<operation>(<MessageName>)"} where the
+ * message name is the command/query name (FQCN) or the event payload simple name, and emits them under
+ * the {@code "axon-framework"} instrumentation scope (the tracer name wired in {@code TracingConfiguration}).
+ * Because Axon Server is used, command/query buses are <b>distributed</b>, so each command yields both the
+ * local ({@code dispatchCommand}/{@code handleCommand}) and distributed
+ * ({@code dispatchDistributedCommand}/{@code handleDistributedCommand}) spans.
+ *
+ * <h2>Stack &amp; determinism</h2>
+ * Axon Server (event store + routing), PostgreSQL (read model) and Jaeger (OTLP backend) all run in Docker
+ * via Testcontainers. Determinism is achieved with: a fresh Jaeger per run, sampling forced to 1.0,
+ * {@code SdkTracerProvider.forceFlush()} before each read (drains the OTLP batch processor), and Awaitility
+ * polling the Jaeger query API until the whole expected span set is present.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestcontainersConfiguration.class)
+@ActiveProfiles({"observability", "observability-jaeger", "axonserver"})
+@Testcontainers
+class JaegerTracingIntegrationTest {
+
+    private static final String SERVICE_NAME = "heroesofddd";
+    private static final Duration LOOKBACK = Duration.ofMinutes(10);
+
+    // ===============================================================================================
+    // THE AXON 4 BASELINE — exact span operation names this flow produces.
+    // (Span name format: "<operation>(<MessageName>)"; "*Distributed*" variants come from Axon Server.)
+    // ===============================================================================================
+
+    /** Spans produced by Axon's own bus/repository/processor SpanFactories (the framework tracing surface). */
+    private static final Set<String> EXPECTED_AXON_FRAMEWORK_SPANS = new TreeSet<>(List.of(
+            // -- CommandBus: dispatch + handle, each in a local and an Axon-Server-distributed variant --
+            "CommandBus.dispatchCommand(BuildDwelling)",
+            "CommandBus.dispatchDistributedCommand(BuildDwelling)",
+            "CommandBus.handleCommand(BuildDwelling)",
+            "CommandBus.handleDistributedCommand(BuildDwelling)",
+            "CommandBus.dispatchCommand(IncreaseAvailableCreatures)",
+            "CommandBus.dispatchDistributedCommand(IncreaseAvailableCreatures)",
+            "CommandBus.handleCommand(IncreaseAvailableCreatures)",
+            "CommandBus.handleDistributedCommand(IncreaseAvailableCreatures)",
+            "CommandBus.dispatchCommand(RecruitCreature)",
+            "CommandBus.dispatchDistributedCommand(RecruitCreature)",
+            "CommandBus.handleCommand(RecruitCreature)",
+            "CommandBus.handleDistributedCommand(RecruitCreature)",
+            "CommandBus.dispatchCommand(AddCreatureToArmy)",
+            "CommandBus.dispatchDistributedCommand(AddCreatureToArmy)",
+            "CommandBus.handleCommand(AddCreatureToArmy)",
+            "CommandBus.handleDistributedCommand(AddCreatureToArmy)",
+            // -- EventBus: one publish span per event + the internal commit span --
+            "EventBus.publishEvent(DwellingBuilt)",
+            "EventBus.publishEvent(AvailableCreaturesChanged)",
+            "EventBus.publishEvent(CreatureRecruited)",
+            "EventBus.publishEvent(CreatureAddedToArmy)",
+            "EventBus.commitEvents",
+            // -- QueryBus: dispatch (local + distributed) + processing + response --
+            "QueryBus.query(GetDwellingById)",
+            "QueryBus.queryDistributed(GetDwellingById)",
+            "QueryBus.processQueryMessage(GetDwellingById)",
+            "QueryBus.processQueryResponse(GetDwellingById)",
+            // -- Repository: event-sourced aggregate loading lifecycle --
+            "Repository.load",
+            "Repository.obtainLock",
+            "Repository.initializeState(Dwelling)",
+            // -- Event processors re-reading the events: pooled/streaming + the subscribing query cache --
+            "StreamingEventProcessor.process(DwellingBuilt)",
+            "StreamingEventProcessor.process(AvailableCreaturesChanged)",
+            "StreamingEventProcessor.process(CreatureRecruited)",
+            "EventProcessor.process(DwellingBuilt)"
+    ));
+
+    /**
+     * Spans for the actual {@code @MessageHandler} method invocations, wrapped by Axon's
+     * {@code TracingHandlerEnhancerDefinition} as {@code "<DeclaringClass>.<method>(<ParamTypes>)"}.
+     * (Aggregate {@code @EventSourcingHandler} replays are intentionally absent because
+     * {@code axon.tracing.show-event-sourcing-handlers=false} — itself a baseline fact this set proves.)
+     */
+    private static final Set<String> EXPECTED_HANDLER_SPANS = new TreeSet<>(List.of(
+            "Dwelling.decide(BuildDwelling)",
+            "Dwelling.decide(IncreaseAvailableCreatures)",
+            "Dwelling.decide(RecruitCreature)",
+            "Army.decide(AddCreatureToArmy)",
+            "DwellingReadModelProjector.on(DwellingBuilt,String)",
+            "DwellingReadModelProjector.on(AvailableCreaturesChanged)",
+            "DwellingReadModelProjector.on(CreatureRecruited)",
+            "WhenCreatureRecruitedThenAddToArmyProcessor.react(CreatureRecruited,String,String)",
+            "WhenWeekSymbolProclaimedThenIncreaseDwellingAvailableCreaturesProcessor.on(DwellingBuilt,String)",
+            "GetAllDwellingsQueryHandler.evolve(DwellingBuilt,String)",
+            "GetDwellingByIdQueryHandler.handle(GetDwellingById)"
+    ));
+
+    /** Spring/Micrometer HTTP <i>server</i> spans (trace roots) — not produced by Axon, but pinned for context. */
+    private static final Set<String> EXPECTED_HTTP_SERVER_SPANS = new TreeSet<>(List.of(
+            "http put /games/{gameId}/dwellings/{dwellingId}",
+            "http put /games/{gameId}/dwellings/{dwellingId}/available-creatures-increases",
+            "http put /games/{gameId}/dwellings/{dwellingId}/creature-recruitments",
+            "http get /games/{gameId}/dwellings/{dwellingId}"
+    ));
+
+    /** Operation-name prefixes owned by Axon's framework SpanFactories — used to police for new/renamed spans. */
+    private static final List<String> AXON_FRAMEWORK_PREFIXES = List.of(
+            "CommandBus.", "EventBus.", "QueryBus.", "Repository.",
+            "StreamingEventProcessor.", "EventProcessor.",
+            "Snapshotter.", "SagaManager.", "DeadlineManager.", "QueryUpdateEmitter."
+    );
+
+    @Container
+    static final GenericContainer<?> JAEGER =
+            new GenericContainer<>(DockerImageName.parse("jaegertracing/jaeger:2.5.0"))
+                    .withExposedPorts(16686, 4318)
+                    .withStartupTimeout(Duration.ofMinutes(2));
+
+    @DynamicPropertySource
+    static void tracingProperties(DynamicPropertyRegistry registry) {
+        // Point OTLP export at the ephemeral Jaeger container (overrides the localhost:4318 default).
+        registry.add(
+                "management.otlp.tracing.endpoint",
+                () -> "http://%s:%d/v1/traces".formatted(JAEGER.getHost(), JAEGER.getMappedPort(4318))
+        );
+        // Re-enable tracing for THIS TEST ONLY. The production profiles are already correct — the
+        // 'observability' profile (application-observability.yaml) sets management.tracing.enabled=true and
+        // that value wins at runtime. But Spring Boot deliberately injects a high-precedence 'test' property
+        // source under @SpringBootTest that forces management.tracing.enabled=false, so we must override it
+        // here (a @DynamicPropertySource outranks the 'test' source). Sampling (1.0) and transport (http)
+        // come from the observability profile and are not disabled in tests.
+        registry.add("management.tracing.enabled", () -> "true");
+    }
+
+    private static JaegerClient jaeger;
+
+    @BeforeAll
+    static void initJaegerClient() {
+        jaeger = new JaegerClient("http://%s:%d".formatted(JAEGER.getHost(), JAEGER.getMappedPort(16686)));
+    }
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    /** Lets us force-drain the OTLP batch processor so spans show up in Jaeger deterministically. */
+    @Autowired
+    ObjectProvider<SdkTracerProvider> tracerProvider;
+
+    /** Present because the {@code axonserver} profile is active; used to wait until the bus is connected. */
+    @Autowired
+    ObjectProvider<AxonServerConnectionManager> axonServerConnectionManager;
+
+    @Nested
+    @DisplayName("Axon 4 tracing baseline for the recruit-a-creature flow")
+    class RecruitCreatureFlow {
+
+        @Test
+        @DisplayName("emits exactly the documented set of Axon spans, with the documented attributes, into Jaeger")
+        void emitsBaselineSpansAndAttributes() {
+            // given
+            awaitAxonServerConnected();
+            var gameId = UUID.randomUUID().toString();
+            var playerId = UUID.randomUUID().toString();
+            var dwellingId = UUID.randomUUID().toString();
+            var armyId = UUID.randomUUID().toString();
+            var creatureId = "angel";
+
+            // when — drive the write model, the cross-aggregate automation, and the read model over REST
+            buildDwelling(gameId, playerId, dwellingId, creatureId);
+            increaseAvailableCreatures(gameId, playerId, dwellingId, creatureId, 5);
+            recruitCreature(gameId, playerId, dwellingId, creatureId, armyId, 2);
+            getDwellingById(gameId, dwellingId);
+
+            // then — poll Jaeger until the entire baseline span set is present (absorbs async export/processors)
+            await().atMost(Duration.ofSeconds(60))
+                   .pollInterval(Duration.ofSeconds(2))
+                   .ignoreExceptions()
+                   .untilAsserted(() -> assertBaseline(flushAndFetchSpans(), gameId, playerId, dwellingId));
+        }
+
+        private void assertBaseline(List<Span> spans, String gameId, String playerId, String dwellingId) {
+            assertThat(spans).isNotEmpty();
+            var operations = distinctOperations(spans);
+
+            // ---------- 1) EXACT span-name catalog (regression signal for renames/removals/additions) ----------
+            // STRICT: the complete set of Axon-emitted spans (those under the "axon-framework" scope —
+            // both the bus/repository/processor spans and the @MessageHandler-invocation spans) must EQUAL
+            // the documented baseline. Any missing span (rename/removal) OR any extra/unexpected span that
+            // does not match the baseline fails here with a concrete diff.
+            var expectedAxonSpans = new TreeSet<String>();
+            expectedAxonSpans.addAll(EXPECTED_AXON_FRAMEWORK_SPANS);
+            expectedAxonSpans.addAll(EXPECTED_HANDLER_SPANS);
+            var actualAxonSpans = spans.stream()
+                    .filter(s -> "axon-framework".equals(s.tags().get("otel.scope.name")))
+                    .map(Span::operationName)
+                    .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+            assertThat(actualAxonSpans)
+                    .as("the exact set of Axon-emitted spans must match the documented baseline "
+                        + "(no missing, no unexpected — update the baseline if the new version intends the change)")
+                    .isEqualTo(expectedAxonSpans);
+
+            // HTTP server spans (Spring/Micrometer; not Axon scope) — assert presence only. Spring also emits
+            // low-cardinality client spans ("http put"/"http get"), so this side is not policed exhaustively.
+            assertThat(operations)
+                    .as("all documented HTTP server spans must be present")
+                    .containsAll(EXPECTED_HTTP_SERVER_SPANS);
+
+            // ---------- 2) Attributes — exact key sets (regression signal for attribute add/remove) ----------
+            // Command dispatch span (local): INTERNAL kind, carries the W3C traceparent it propagates downstream.
+            var dispatchRecruit = findSpan(spans, "CommandBus.dispatchCommand(RecruitCreature)");
+            assertTagKeys(dispatchRecruit,
+                          "axon_message_id", "axon_message_name", "axon_message_type",
+                          "axon_metadata_gameId", "axon_metadata_playerId", "axon_metadata_traceparent",
+                          "axon_payload_type", "otel.scope.name", "span.kind");
+
+            // Command handling span: CONSUMER kind, same attribute set.
+            var handleRecruit = findSpan(spans, "CommandBus.handleCommand(RecruitCreature)");
+            assertTagKeys(handleRecruit,
+                          "axon_message_id", "axon_message_name", "axon_message_type",
+                          "axon_metadata_gameId", "axon_metadata_playerId", "axon_metadata_traceparent",
+                          "axon_payload_type", "otel.scope.name", "span.kind");
+
+            // Event publish span: PRODUCER kind. NOTE the baseline asymmetry — it has correlationId/traceId
+            // (Axon causation metadata) but NO traceparent (that is injected on the async dispatch path).
+            var recruitPublish = findSpan(spans, "EventBus.publishEvent(CreatureRecruited)");
+            assertTagKeys(recruitPublish,
+                          "axon_aggregate_identifier", "axon_message_id", "axon_message_type",
+                          "axon_metadata_correlationId", "axon_metadata_gameId", "axon_metadata_playerId",
+                          "axon_metadata_traceId", "axon_payload_type", "otel.scope.name", "span.kind");
+
+            // Async event-processing span: CONSUMER kind, tracked-event type, and it DOES carry traceparent.
+            var processRecruit = findSpan(spans, "StreamingEventProcessor.process(CreatureRecruited)");
+            assertTagKeys(processRecruit,
+                          "axon_aggregate_identifier", "axon_message_id", "axon_message_type",
+                          "axon_metadata_correlationId", "axon_metadata_gameId", "axon_metadata_playerId",
+                          "axon_metadata_traceId", "axon_metadata_traceparent", "axon_payload_type",
+                          "otel.scope.name", "span.kind");
+
+            // Query processing span: CONSUMER kind. NO gameId metadata — the query is dispatched without it.
+            var processQuery = findSpan(spans, "QueryBus.processQueryMessage(GetDwellingById)");
+            assertTagKeys(processQuery,
+                          "axon_message_id", "axon_message_name", "axon_message_type",
+                          "axon_metadata_traceparent", "axon_payload_type", "otel.scope.name", "span.kind");
+
+            // Handler-enhancer span: ONLY scope + kind (message attribute providers do not run for these).
+            var decideRecruit = findSpan(spans, "Dwelling.decide(RecruitCreature)");
+            assertTagKeys(decideRecruit, "otel.scope.name", "span.kind");
+
+            // ---------- 3) Attributes — exact values (regression signal for value/format changes) ----------
+            // Instrumentation scope == the tracer name wired in TracingConfiguration, on EVERY Axon span.
+            assertThat(spans.stream().filter(s -> isAxonFrameworkSpan(s.operationName())))
+                    .as("every Axon framework span is emitted under the 'axon-framework' scope")
+                    .allMatch(s -> "axon-framework".equals(s.tags().get("otel.scope.name")));
+
+            // span.kind mapping (CONSUMER=handling, PRODUCER=publishing, INTERNAL=local dispatch/handler).
+            assertTag(dispatchRecruit, "span.kind", "internal");
+            assertTag(handleRecruit, "span.kind", "consumer");
+            assertTag(recruitPublish, "span.kind", "producer");
+            assertTag(processRecruit, "span.kind", "consumer");
+            assertTag(decideRecruit, "span.kind", "internal");
+
+            // Message identity attributes (Axon Server distribution shows up in the message TYPE).
+            assertTag(handleRecruit, "axon_message_type", "GrpcBackedCommandMessage");
+            assertTag(handleRecruit, "axon_message_name", RecruitCreature.class.getName());
+            assertTag(handleRecruit, "axon_payload_type", RecruitCreature.class.getName());
+            assertTag(handleRecruit, "axon_metadata_" + GameMetaData.GAME_ID_KEY, gameId);
+            assertTag(handleRecruit, "axon_metadata_" + GameMetaData.PLAYER_ID_KEY, playerId);
+
+            assertTag(recruitPublish, "axon_message_type", "GenericDomainEventMessage");
+            assertTag(recruitPublish, "axon_payload_type", CreatureRecruited.class.getName());
+            assertTag(recruitPublish, "axon_aggregate_identifier", "Dwelling:" + dwellingId);
+            assertTag(recruitPublish, "axon_metadata_" + GameMetaData.GAME_ID_KEY, gameId);
+
+            assertTag(processRecruit, "axon_message_type", "GenericTrackedDomainEventMessage");
+            assertTag(processRecruit, "axon_aggregate_identifier", "Dwelling:" + dwellingId);
+
+            assertTag(processQuery, "axon_message_type", "GrpcBackedQueryMessage");
+            assertTag(processQuery, "axon_message_name", GetDwellingById.class.getName());
+            assertTag(processQuery, "axon_payload_type", GetDwellingById.class.getName());
+
+            // HTTP server span (Spring/Micrometer) — pinned for the trace-root context.
+            var httpPut = findSpan(spans, "http put /games/{gameId}/dwellings/{dwellingId}");
+            assertTag(httpPut, "span.kind", "server");
+            assertTag(httpPut, "method", "PUT");
+            assertTag(httpPut, "status", "200");
+            assertTag(httpPut, "outcome", "SUCCESS");
+            assertTag(httpPut, "uri", "/games/{gameId}/dwellings/{dwellingId}");
+
+            // ---------- 4) Causation + W3C context propagation (regression signal for broken correlation) ----------
+            // The recruit event's correlationId/traceId point back to the originating command's message id.
+            var recruitCommandId = dispatchRecruit.tags().get("axon_message_id");
+            assertThat(recruitCommandId).as("dispatch span exposes the command message id").isNotBlank();
+            assertTag(recruitPublish, "axon_metadata_correlationId", recruitCommandId);
+            assertTag(recruitPublish, "axon_metadata_traceId", recruitCommandId);
+
+            // traceparent is a well-formed W3C header, and the async handler stays in the SAME trace as dispatch.
+            assertW3cTraceparent(dispatchRecruit);
+            assertW3cTraceparent(processRecruit);
+            assertThat(processRecruit.tags().get("axon_metadata_traceparent"))
+                    .as("async event handler must stay within the dispatching command's W3C trace")
+                    .contains(w3cTraceId(dispatchRecruit));
+
+            // Sanity: the unique gameId correlates many spans across the whole flow.
+            assertThat(spans.stream().filter(s -> gameId.equals(s.tags().get("axon_metadata_" + GameMetaData.GAME_ID_KEY))))
+                    .as("the unique gameId correlates commands, events and async handlers")
+                    .hasSizeGreaterThanOrEqualTo(10);
+        }
+
+        private boolean isAxonFrameworkSpan(String operationName) {
+            return AXON_FRAMEWORK_PREFIXES.stream().anyMatch(operationName::startsWith);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // HTTP helpers (mirror the production REST controllers)
+    // ---------------------------------------------------------------------------------------------
+
+    private void buildDwelling(String gameId, String playerId, String dwellingId, String creatureId) {
+        var body = Map.of("creatureId", creatureId, "costPerTroop", Map.of("GOLD", 3000, "GEMS", 1));
+        put("/games/%s/dwellings/%s".formatted(gameId, dwellingId), playerId, body);
+    }
+
+    private void increaseAvailableCreatures(String gameId, String playerId, String dwellingId,
+                                            String creatureId, int increaseBy) {
+        var body = Map.of("creatureId", creatureId, "increaseBy", increaseBy);
+        put("/games/%s/dwellings/%s/available-creatures-increases".formatted(gameId, dwellingId), playerId, body);
+    }
+
+    private void recruitCreature(String gameId, String playerId, String dwellingId, String creatureId,
+                                 String armyId, int quantity) {
+        // expectedCost must equal costPerTroop * quantity (GOLD 3000, GEMS 1) per the Dwelling aggregate rule
+        var body = Map.of(
+                "creatureId", creatureId,
+                "armyId", armyId,
+                "quantity", quantity,
+                "expectedCost", Map.of("GOLD", 3000 * quantity, "GEMS", quantity)
+        );
+        put("/games/%s/dwellings/%s/creature-recruitments".formatted(gameId, dwellingId), playerId, body);
+    }
+
+    private void getDwellingById(String gameId, String dwellingId) {
+        var response = restTemplate.getForEntity(
+                url("/games/%s/dwellings/%s".formatted(gameId, dwellingId)), String.class);
+        // The read model may not be projected yet (async); we only care that the query span is emitted.
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+    }
+
+    private void put(String path, String playerId, Map<String, ?> body) {
+        var headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-player-id", playerId);
+        var response = restTemplate.exchange(
+                url(path), HttpMethod.PUT, new HttpEntity<>(body, headers), Void.class);
+        assertThat(response.getStatusCode()).as("PUT %s should succeed", path).isEqualTo(HttpStatus.OK);
+    }
+
+    private String url(String path) {
+        return "http://localhost:%d%s".formatted(port, path);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Tracing helpers
+    // ---------------------------------------------------------------------------------------------
+
+    private List<Span> flushAndFetchSpans() {
+        // Drain the OTLP BatchSpanProcessor so anything already ended is exported now, then read it back.
+        tracerProvider.ifAvailable(provider -> provider.forceFlush().join(10, TimeUnit.SECONDS));
+        return jaeger.fetchSpans(SERVICE_NAME, LOOKBACK);
+    }
+
+    private static Set<String> distinctOperations(List<Span> spans) {
+        return spans.stream().map(Span::operationName).collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+    }
+
+    private Span findSpan(List<Span> spans, String exactOperationName) {
+        return spans.stream()
+                    .filter(s -> s.operationName().equals(exactOperationName))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                            "No span named '%s'. Present operations: %s".formatted(
+                                    exactOperationName, distinctOperations(spans))));
+    }
+
+    private void assertTag(Span span, String key, String expectedValue) {
+        assertThat(span.tags().get(key))
+                .as("span '%s' tag '%s'", span.operationName(), key)
+                .isEqualTo(expectedValue);
+    }
+
+    private void assertTagKeys(Span span, String... expectedKeys) {
+        assertThat(span.tags().keySet())
+                .as("span '%s' attribute keys", span.operationName())
+                .containsExactlyInAnyOrder(expectedKeys);
+    }
+
+    /** Asserts the span carries a well-formed W3C {@code traceparent}: {@code 00-<32hex>-<16hex>-<2hex>}. */
+    private void assertW3cTraceparent(Span span) {
+        assertThat(span.tags().get("axon_metadata_traceparent"))
+                .as("span '%s' W3C traceparent", span.operationName())
+                .matches("00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}");
+    }
+
+    /** Extracts the 32-hex trace-id from a span's W3C traceparent. */
+    private String w3cTraceId(Span span) {
+        return span.tags().get("axon_metadata_traceparent").split("-")[1];
+    }
+
+    private void awaitAxonServerConnected() {
+        axonServerConnectionManager.ifAvailable(manager ->
+                await().atMost(Duration.ofSeconds(15))
+                       .untilAsserted(() -> assertThat(manager.getConnection().isConnected()).isTrue()));
+    }
+}

--- a/src/test/java/com/dddheroes/heroesofddd/observability/JaegerTracingIntegrationTest.java
+++ b/src/test/java/com/dddheroes/heroesofddd/observability/JaegerTracingIntegrationTest.java
@@ -163,6 +163,20 @@ class JaegerTracingIntegrationTest {
             "result-set"   // result-set traversal
     ));
 
+    /**
+     * gRPC client spans for the Axon Server connector (scope {@code io.opentelemetry.grpc-1.6}), named
+     * {@code <rpc.service>/<rpc.method>}. Only the <b>unary</b> RPCs of the recruit flow are pinned here —
+     * they complete and export within the run. Axon Server's long-lived bidirectional streams (command/query/
+     * event/control channels) open one span that lasts the whole connection, so they do not end during the
+     * test and are intentionally not asserted.
+     */
+    private static final Set<String> EXPECTED_GRPC_SPANS = new TreeSet<>(List.of(
+            "io.axoniq.axonserver.grpc.command.CommandService/Dispatch",     // command sent to Axon Server
+            "io.axoniq.axonserver.grpc.query.QueryService/Query",            // GetDwellingById query
+            "io.axoniq.axonserver.grpc.event.EventStore/AppendEvent",        // events appended to the store
+            "io.axoniq.axonserver.grpc.event.EventStore/ListAggregateEvents" // aggregate loading
+    ));
+
     /** Operation-name prefixes owned by Axon's framework SpanFactories — used to police for new/renamed spans. */
     private static final List<String> AXON_FRAMEWORK_PREFIXES = List.of(
             "CommandBus.", "EventBus.", "QueryBus.", "Repository.",
@@ -274,6 +288,12 @@ class JaegerTracingIntegrationTest {
                     .as("all documented JPA/JDBC spans must be present")
                     .containsAll(EXPECTED_JPA_SPANS);
 
+            // gRPC client spans (Axon Server connector) — assert presence of the unary RPCs. Count varies
+            // (snapshots, token calls, retries, long-lived streams), so not policed exhaustively.
+            assertThat(operations)
+                    .as("all documented gRPC (Axon Server) spans must be present")
+                    .containsAll(EXPECTED_GRPC_SPANS);
+
             // ---------- 2) Attributes — exact key sets (regression signal for attribute add/remove) ----------
             // Command dispatch span (local): INTERNAL kind, carries the W3C traceparent it propagates downstream.
             var dispatchRecruit = findSpan(spans, "CommandBus.dispatchCommand(RecruitCreature)");
@@ -362,6 +382,15 @@ class JaegerTracingIntegrationTest {
             assertThat(querySpan.tags())
                     .as("query span must carry the executed SQL on the jdbc.query[0] tag")
                     .containsKey("jdbc.query[0]");
+
+            // gRPC client span (Axon Server connector): standard OTel RPC attributes, scope grpc-1.6.
+            var grpcDispatch = findSpan(spans, "io.axoniq.axonserver.grpc.command.CommandService/Dispatch");
+            assertTag(grpcDispatch, "otel.scope.name", "io.opentelemetry.grpc-1.6");
+            assertTag(grpcDispatch, "span.kind", "client");
+            assertTag(grpcDispatch, "rpc.system", "grpc");
+            assertTag(grpcDispatch, "rpc.service", "io.axoniq.axonserver.grpc.command.CommandService");
+            assertTag(grpcDispatch, "rpc.method", "Dispatch");
+            assertTag(grpcDispatch, "rpc.grpc.status_code", "0");   // OK
 
             // ---------- 4) Causation + W3C context propagation (regression signal for broken correlation) ----------
             // The recruit event's correlationId/traceId point back to the originating command's message id.

--- a/src/test/java/com/dddheroes/heroesofddd/observability/JaegerTracingIntegrationTest.java
+++ b/src/test/java/com/dddheroes/heroesofddd/observability/JaegerTracingIntegrationTest.java
@@ -26,6 +26,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.util.ClassUtils;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -177,6 +178,20 @@ class JaegerTracingIntegrationTest {
             "io.axoniq.axonserver.grpc.event.EventStore/ListAggregateEvents" // aggregate loading
     ));
 
+    /**
+     * JDBC/JPA and gRPC tracing are opt-in BUILD-TIME toggles (Maven {@code tracing-database} /
+     * {@code tracing-grpc} profiles, enabled with {@code -Dtracing.database.enabled=true} /
+     * {@code -Dtracing.grpc.enabled=true}). When a feature's instrumentation JAR is not built in, it cannot
+     * produce spans, so the corresponding baseline assertions below are skipped rather than failing. Detect
+     * each JAR by a marker class on the runtime classpath. Build with both flags to exercise the full baseline.
+     */
+    private static final boolean JDBC_TRACING_PRESENT = ClassUtils.isPresent(
+            "net.ttddyy.observation.boot.autoconfigure.DataSourceObservationAutoConfiguration",
+            JaegerTracingIntegrationTest.class.getClassLoader());
+    private static final boolean GRPC_TRACING_PRESENT = ClassUtils.isPresent(
+            "io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry",
+            JaegerTracingIntegrationTest.class.getClassLoader());
+
     /** Operation-name prefixes owned by Axon's framework SpanFactories — used to police for new/renamed spans. */
     private static final List<String> AXON_FRAMEWORK_PREFIXES = List.of(
             "CommandBus.", "EventBus.", "QueryBus.", "Repository.",
@@ -283,16 +298,28 @@ class JaegerTracingIntegrationTest {
                     .containsAll(EXPECTED_HTTP_SERVER_SPANS);
 
             // JPA/JDBC spans (datasource-micrometer) — assert presence. Their count/SQL varies per run, so
-            // this side is not policed exhaustively either.
-            assertThat(operations)
-                    .as("all documented JPA/JDBC spans must be present")
-                    .containsAll(EXPECTED_JPA_SPANS);
+            // this side is not policed exhaustively either. Only when the opt-in JDBC tracing JAR is built in
+            // (-Dtracing.database.enabled=true); otherwise no such spans are produced (see *_TRACING_PRESENT).
+            if (JDBC_TRACING_PRESENT) {
+                assertThat(operations)
+                        .as("all documented JPA/JDBC spans must be present")
+                        .containsAll(EXPECTED_JPA_SPANS);
+            } else {
+                System.out.println("[baseline] JDBC/JPA tracing JAR not on classpath — skipping JPA span assertions "
+                                   + "(build with -Dtracing.database.enabled=true to exercise them).");
+            }
 
             // gRPC client spans (Axon Server connector) — assert presence of the unary RPCs. Count varies
-            // (snapshots, token calls, retries, long-lived streams), so not policed exhaustively.
-            assertThat(operations)
-                    .as("all documented gRPC (Axon Server) spans must be present")
-                    .containsAll(EXPECTED_GRPC_SPANS);
+            // (snapshots, token calls, retries, long-lived streams), so not policed exhaustively. Only when the
+            // opt-in gRPC tracing JAR is built in (-Dtracing.grpc.enabled=true).
+            if (GRPC_TRACING_PRESENT) {
+                assertThat(operations)
+                        .as("all documented gRPC (Axon Server) spans must be present")
+                        .containsAll(EXPECTED_GRPC_SPANS);
+            } else {
+                System.out.println("[baseline] gRPC tracing JAR not on classpath — skipping gRPC span assertions "
+                                   + "(build with -Dtracing.grpc.enabled=true to exercise them).");
+            }
 
             // ---------- 2) Attributes — exact key sets (regression signal for attribute add/remove) ----------
             // Command dispatch span (local): INTERNAL kind, carries the W3C traceparent it propagates downstream.
@@ -376,21 +403,27 @@ class JaegerTracingIntegrationTest {
             assertTag(httpPut, "uri", "/games/{gameId}/dwellings/{dwellingId}");
 
             // JPA/JDBC query span (datasource-micrometer): CLIENT kind, PostgreSQL driver, SQL text present.
-            var querySpan = findSpan(spans, "query");
-            assertTag(querySpan, "span.kind", "client");
-            assertTag(querySpan, "jdbc.datasource.driver", "org.postgresql.Driver");
-            assertThat(querySpan.tags())
-                    .as("query span must carry the executed SQL on the jdbc.query[0] tag")
-                    .containsKey("jdbc.query[0]");
+            // Only asserted when the opt-in JDBC tracing JAR is built in (see JDBC_TRACING_PRESENT).
+            if (JDBC_TRACING_PRESENT) {
+                var querySpan = findSpan(spans, "query");
+                assertTag(querySpan, "span.kind", "client");
+                assertTag(querySpan, "jdbc.datasource.driver", "org.postgresql.Driver");
+                assertThat(querySpan.tags())
+                        .as("query span must carry the executed SQL on the jdbc.query[0] tag")
+                        .containsKey("jdbc.query[0]");
+            }
 
             // gRPC client span (Axon Server connector): standard OTel RPC attributes, scope grpc-1.6.
-            var grpcDispatch = findSpan(spans, "io.axoniq.axonserver.grpc.command.CommandService/Dispatch");
-            assertTag(grpcDispatch, "otel.scope.name", "io.opentelemetry.grpc-1.6");
-            assertTag(grpcDispatch, "span.kind", "client");
-            assertTag(grpcDispatch, "rpc.system", "grpc");
-            assertTag(grpcDispatch, "rpc.service", "io.axoniq.axonserver.grpc.command.CommandService");
-            assertTag(grpcDispatch, "rpc.method", "Dispatch");
-            assertTag(grpcDispatch, "rpc.grpc.status_code", "0");   // OK
+            // Only asserted when the opt-in gRPC tracing JAR is built in (see GRPC_TRACING_PRESENT).
+            if (GRPC_TRACING_PRESENT) {
+                var grpcDispatch = findSpan(spans, "io.axoniq.axonserver.grpc.command.CommandService/Dispatch");
+                assertTag(grpcDispatch, "otel.scope.name", "io.opentelemetry.grpc-1.6");
+                assertTag(grpcDispatch, "span.kind", "client");
+                assertTag(grpcDispatch, "rpc.system", "grpc");
+                assertTag(grpcDispatch, "rpc.service", "io.axoniq.axonserver.grpc.command.CommandService");
+                assertTag(grpcDispatch, "rpc.method", "Dispatch");
+                assertTag(grpcDispatch, "rpc.grpc.status_code", "0");   // OK
+            }
 
             // ---------- 4) Causation + W3C context propagation (regression signal for broken correlation) ----------
             // The recruit event's correlationId/traceId point back to the originating command's message id.


### PR DESCRIPTION
Adds distributed tracing and observability to the **Axon Framework 4** sample: Micrometer-based JDBC/SQL and gRPC (Axon Server connector) tracing as opt-in Maven build toggles, background parentless-trace filtering, Elastic APM and Jaeger backends via Docker Compose, and a Jaeger golden-master integration test that pins the expected span topology. Adds examples of AF4 query types in creature recruitment — list, stream, and watch dwellings — each with a query, handler, REST endpoint, tests, and `.http` request samples.

This is the **AF4 baseline** counterpart to the AF5 tracing work, so the two frameworks can be compared span-for-span.

## What's included

- **JDBC/JPA tracing** via `datasource-micrometer` — every SQL statement (Axon JPA event store + read-model projections) becomes a child span.
- **gRPC tracing** for the Axon Server connector via `opentelemetry-grpc`.
- **Opt-in build toggles** — the instrumentation JARs are excluded from a default build and pulled in only via the `tracing-database` / `tracing-grpc` Maven profiles (see below).
- **Parentless background-trace filtering** — drops orphan background JDBC/connection traces so the Jaeger UI stays focused on request-scoped work.
- **Jaeger golden-master test** (`JaegerTracingIntegrationTest` + `JaegerClient`) plus `AXON4_TRACING_BASELINE.md` documenting the expected topology.
- **AF4 query-type examples** — `ListDwellings` (multi-result), `StreamDwellings`, and `WatchDwelling` (subscription), each with query, handler, REST endpoint, tests, and `.http` samples.
- **Fix:** give each read model its own index name to avoid a Postgres collision; make the multi-result query work over Axon Server.

## How to run

Tracing is **off by default**. To see the full Jaeger trace waterfall:

1. **Start the Jaeger backend first** (base compose + Jaeger overlay):
   ```bash
   docker compose -f docker-compose.yaml -f docker-compose.observability-jaeger.yaml up -d
   ```
2. **Run the app** with the Jaeger observability profile and the build-time tracing toggles:
   ```bash
   SPRING_PROFILES_ACTIVE=observability-jaeger,axonserver \
     ./mvnw spring-boot:run -Dtracing.database.enabled=true -Dtracing.grpc.enabled=true
   ```
   - `observability-jaeger` activates the base `observability` profile (sampling, OTLP/HTTP transport) via a Spring profile group and points the OTLP exporter at `http://localhost:4318/v1/traces`.
   - App default URL: **http://localhost:3773**

### Build toggles: `tracing.database.enabled` / `tracing.grpc.enabled`

These are **build-time** Maven property toggles that activate the `tracing-database` / `tracing-grpc` profiles in `pom.xml`, pulling in the `datasource-micrometer` (JDBC/SQL) and `opentelemetry-grpc` (Axon Server gRPC) instrumentation JARs — which are excluded from a default build. Without them you still get HTTP/Axon spans, but **no SQL or gRPC spans**: the JAR must be present **and** the `observability` profile active.

> Note: gRPC spans only appear when the app connects to **Axon Server** (run with the `axonserver` profile). On the default JPA event store there is no gRPC, so `-Dtracing.grpc.enabled=true` is a no-op there.

## See traces in the Jaeger UI

With the app running, fire the requests in `generated-requests.http` top-to-bottom (against the default port **3773**):

- **BuildDwelling #1/#2** → creates dwellings
- **GetDwellingById**, **ListDwellings**, **StreamDwellings** → query examples
- **WatchDwelling** (leave running), then **IncreaseAvailableCreatures** / **RecruitCreature** → subscription updates

Then open the **Jaeger UI at http://localhost:16686**, pick the app service, and inspect the span waterfalls (HTTP → Axon command/query/event handlers → JDBC/SQL, plus gRPC when on Axon Server).


## Validation

- Latest GitHub Actions `build` check passes on commit `4a79396`.
- Local `./mvnw test -Dtracing.database.enabled=true -Dtracing.grpc.enabled=true` passes: 108 tests, 0 failures, 0 errors.
- The golden-master includes the two `QueryUpdateEmitter` spans emitted by subscription updates.